### PR TITLE
Added options to filter video search by clip duration

### DIFF
--- a/GettyImages.Api/ApiRequest.cs
+++ b/GettyImages.Api/ApiRequest.cs
@@ -413,6 +413,22 @@ namespace GettyImages.Api
             }
         }
 
+        protected void AddMinimumDuration(int value)
+        {
+            if (QueryParameters.ContainsKey(Constants.MinimumVideoDurationKey))
+                QueryParameters[Constants.MinimumVideoDurationKey] = value;
+            else
+                QueryParameters.Add(Constants.MinimumVideoDurationKey, value);
+        }
+
+        protected void AddMaximumDuration(int value)
+        {
+            if (QueryParameters.ContainsKey(Constants.MaximumVideoDurationKey))
+                QueryParameters[Constants.MaximumVideoDurationKey] = value;
+            else
+                QueryParameters.Add(Constants.MaximumVideoDurationKey, value);
+        }
+
         protected void AddNumberOfPeople(NumberOfPeople value)
         {
             if (QueryParameters.ContainsKey(Constants.NumberOfPeopleKey))

--- a/GettyImages.Api/Constants.cs
+++ b/GettyImages.Api/Constants.cs
@@ -44,6 +44,8 @@ namespace GettyImages.Api
         public const string LicenseModelsKey = "license_models";
         public const string MinimumQualityKey = "minimum_quality_rank";
         public const string MinimumSizeKey = "minimum_size";
+        public const string MinimumVideoDurationKey = "minimum_duration";
+        public const string MaximumVideoDurationKey = "maximum_duration";
         public const string NumberOfPeopleKey = "number_of_people";
         public const string OrientationsKey = "orientations";
         public const string PageKey = "page";

--- a/GettyImages.Api/Search/SearchVideos.cs
+++ b/GettyImages.Api/Search/SearchVideos.cs
@@ -95,6 +95,18 @@ namespace GettyImages.Api.Search
             return this;
         }
 
+        public SearchVideos WithMinimumDuration(int value)
+        {
+            AddMinimumDuration(value);
+            return this;
+        }
+
+        public SearchVideos WithMaximumDuration(int value)
+        {
+            AddMaximumDuration(value);
+            return this;
+        }
+
         public SearchVideos WithPage(int value)
         {
             AddQueryParameter(Constants.PageKey, value);

--- a/GettyImages.Api/Search/SearchVideosCreative.cs
+++ b/GettyImages.Api/Search/SearchVideosCreative.cs
@@ -88,6 +88,18 @@ namespace GettyImages.Api.Search
             return this;
         }
 
+        public SearchVideosCreative WithMinimumDuration(int value)
+        {
+            AddMinimumDuration(value);
+            return this;
+        }
+
+        public SearchVideosCreative WithMaximumDuration(int value)
+        {
+            AddMaximumDuration(value);
+            return this;
+        }
+
         public SearchVideosCreative WithPage(int value)
         {
             AddQueryParameter(Constants.PageKey, value);

--- a/GettyImages.Api/Search/SearchVideosEditorial.cs
+++ b/GettyImages.Api/Search/SearchVideosEditorial.cs
@@ -94,6 +94,18 @@ namespace GettyImages.Api.Search
             return this;
         }
 
+        public SearchVideosEditorial WithMinimumDuration(int value)
+        {
+            AddMinimumDuration(value);
+            return this;
+        }
+
+        public SearchVideosEditorial WithMaximumDuration(int value)
+        {
+            AddMaximumDuration(value);
+            return this;
+        }
+
         public SearchVideosEditorial WithPage(int value)
         {
             AddQueryParameter(Constants.PageKey, value);

--- a/UnitTests/Search/SearchVideosCreativeTests.cs
+++ b/UnitTests/Search/SearchVideosCreativeTests.cs
@@ -206,5 +206,45 @@ namespace UnitTests.Search
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("release_status=release_not_important");
         }
+
+        [Fact]
+        public void SearchForCreativeVideosWithMinimumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMinimumDuration(20).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+        }
+
+        [Fact]
+        public void SearchForCreativeVideosWithMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
+
+        [Fact]
+        public void SearchForCreativeVideosWithMinimumAndMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMinimumDuration(20).WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
     }
 }

--- a/UnitTests/Search/SearchVideosEditorialTests.cs
+++ b/UnitTests/Search/SearchVideosEditorialTests.cs
@@ -238,5 +238,45 @@ namespace UnitTests.Search
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("release_status=fully_released");
         }
+
+        [Fact]
+        public void SearchForEditorialVideosWithMinimumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMinimumDuration(20).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+        }
+
+        [Fact]
+        public void SearchForEditorialVideosWithMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
+
+        [Fact]
+        public void SearchForEditorialVideosWithMinimumAndMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMinimumDuration(20).WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
     }
 }

--- a/UnitTests/Search/SearchVideosTests.cs
+++ b/UnitTests/Search/SearchVideosTests.cs
@@ -235,5 +235,45 @@ namespace UnitTests.Search
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("release_status=fully_released");
         }
+
+        [Fact]
+        public void SearchForVideosWithMinimumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMinimumDuration(20).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+        }
+
+        [Fact]
+        public void SearchForVideosWithMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
+
+        [Fact]
+        public void SearchForVideosWithMinimumAndMaximumDuration()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMinimumDuration(20).WithMaximumDuration(200).ExecuteAsync().Result;
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("minimum_duration=20");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("maximum_duration=200");
+        }
     }
 }


### PR DESCRIPTION
Adding two new methods to include the ability to filter video search by length.  And associated tests