### PR TITLE
Remove License Model

### DIFF
--- a/GettyImages.Api/Search/SearchImages.cs
+++ b/GettyImages.Api/Search/SearchImages.cs
@@ -134,12 +134,6 @@ namespace GettyImages.Api.Search
             return this;
         }
 
-        public virtual SearchImages WithLicenseModel(LicenseModel value)
-        {
-            AddLicenseModel(value);
-            return this;
-        }
-
         public SearchImages WithMinimumSize(MinimumSize value)
         {
             AddQueryParameter(Constants.MinimumSizeKey, value);

--- a/GettyImages.Api/Search/SearchImagesCreative.cs
+++ b/GettyImages.Api/Search/SearchImagesCreative.cs
@@ -131,12 +131,6 @@ namespace GettyImages.Api.Search
             return this;
         }
 
-        public virtual SearchImagesCreative WithLicenseModel(LicenseModel value)
-        {
-            AddLicenseModel(value);
-            return this;
-        }
-
         public SearchImagesCreative WithMinimumSize(MinimumSize value)
         {
             AddQueryParameter(Constants.MinimumSizeKey, value);

--- a/UnitTests/Search/SearchImagesCreativeTests.cs
+++ b/UnitTests/Search/SearchImagesCreativeTests.cs
@@ -237,19 +237,6 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithLicenseModel()
-        {
-            var testHandler = TestUtil.CreateTestHandler();
-
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsManaged | LicenseModel.RoyaltyFree).ExecuteAsync().Result;
-
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("license_models=rightsmanaged%2Croyaltyfree");
-        }
-
-        [Fact]
         public void SearchForCreativeImagesWithMinimumSize()
         {
             var testHandler = TestUtil.CreateTestHandler();

--- a/UnitTests/Search/SearchImagesTests.cs
+++ b/UnitTests/Search/SearchImagesTests.cs
@@ -301,19 +301,6 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithLicenseModel()
-        {
-            var testHandler = TestUtil.CreateTestHandler();
-
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsManaged | LicenseModel.RoyaltyFree).ExecuteAsync().Result;
-
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("license_models=rightsmanaged%2Croyaltyfree");
-        }
-
-        [Fact]
         public void SearchForBlendedImagesWithMinimumSize()
         {
             var testHandler = TestUtil.CreateTestHandler();


### PR DESCRIPTION
Remove License Model from Search/Images and Search/Creative-Images

Remove from API
Remove from Unit tests to reflect the major change
This is a major change