### PR TITLE
Update testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ _ReSharper*
 *.feature.cs
 *~
 .vs/
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,17 @@ env:
   - secure: eCV8oUcxQeRF51JhMjTQ83ikmqCVBBGSbYb3Np7sOvECGfWftVy0m4RB9Swidko45qCV5QPCWJsKXdgZqlBV6sNW7CW3q6zdeSVpSl9RS4a+CC3qpd68xHQqQ8bGppxy67RTkdRL4AkyE24rGdie4VVZCAaIZp4L98BntZYK5Iy9SebVF9QxbL2KKKjKrSpy/SsqjuR2EQlL7T60oCtpbU5dbA1kPijPEFD7BF6zpsQMHCKjZU64AZqJmYFtWc7Y0Bi3kex/XuiO/PYfMDioIgoUnsLMqgx2/koexOkRj4jUoG/rzamRfMSqFLZO8LJkjVjfu9T1gw/nmmRbEjiTsAUh84ixv/o9hft+ngu+qKi6/Jud9DMuEDDeb+ErCWykXuXxfhOyBAuIefCgTuMKZlbNUkgErmJ8psD1kWCYLvLkzlyQ0Pf7R+wuhcbkJcOh2AdXnia+u5vQ1o4n7eKiNmjL7Roqzq/33fWf3ZZu9RK0ZWRbqbM9hNuRu/6y3HlZoGKvp1gZVLC5pJ56uaxdmllzF95+KFnEhOqnu47yF6wgmPMLUPIIsKdwaV71AOwpXT/yTd3DpMTpCJ10yxGtjB6lwOjgCcxKl3JesLKaT61CKLvr8XlJR64VZVfkVEfZdHAjxyyHEUnottKjQlmSSdSfpLBm8JOA+W1AnfIP10M=
   - secure: pgQ5TUQQXzHGCEweNP14I4z6/XI7n3muOQLHsecKF9NQHAUv88eyUDGuyVSretr0rbyBzuxr1lDxTu902fkBrrBqcTXwloSqBfJfnhEbhU02eRXohg1D1LVbnbn4P+Mj73Iv31DCXeM/soHMNgwcczCSIDoZHMAcT8q8Yk/uMLf4QzDBjJCytEb3KuWEUJ30VxPhryBv3wUi+PHa7pZIbAUtkXA9YEBsZbzbIify+/j110cbPyqstYExuYCVdAPAWSyXLmUgonLQKxg6NTwCDySMTMj4oOckHy99YbaBKt3douNevHeNvJ88ZSZ9aQjp0yu/2Pp6DCmCbbIkjFoOH2af2jYaBlTi4faXC3YVmzVXW3xI+cjCPKvXRcf9Eg4F66lURtCwXAJkqRqLC7+ZxPs1q0kb//NAvVPS7caS7k1smzOLLbO/kWFmCaZqprO5v3zccoobv/HNg43LYvj9r0912rsgyEMRV7k76waQD4RAsZlvRyNHthepktptT1TKFW+AVusV4qZVAulBU6b+OHrWGZ489gTTz7YAAirjjEU/qFmNYwfv8i1WWDDzUlUPRlUndf/ylDvFEfCE+P+uOcuGPexYaRjDfi8BQ4HIb2nSwXAaxF2sbPzZuL4xNB9nAVyJhq3GhckHUkHflnvQme5bYBfSKDCDwk9IJCACB/k=
 mono: none
-dotnet: # Test against LTS versions. Version numbers are for SDK
+# Test against multiple SDKs
+# We want to make sure we're working with all LTS versions.
+# In the unit test project we use the TargetFrameworks (note the S) moniker to target multiple frameworks
+# In Travis we need to have all the target frameworks installed, and explicitly include each framework in the test runs.
+# dotnet: * include one of the frameworks
+# before_install: * explicitly install other targeted SDKs side by side
+# script: * explicitly identify the framework when invoking the tests
+dotnet: # Include one of the frameworks
   - 2.1.804 # EOL for 2.1: 2021.08.21
-  #- 3.1.102 # EOL for 3.1: 2022.12.03
 before_install:
+  # explicitly install other targeted SDKs side by side
   - sudo apt-get install dotnet-sdk-3.1
 script:
 # If this is not a pull request and the commit is tagged, set the package version to the git tag
@@ -21,6 +28,7 @@ script:
 - sed -i -e "s/>0.0.0</>$PACKAGE_VERSION</" ./GettyImages.Api/GettyImages.Api.csproj
 - cat ./GettyImages.Api/GettyImages.Api.csproj
 - dotnet build -c Release
+#  explicitly identify the framework when invoking the tests
 - dotnet test UnitTests/UnitTests.csproj -f netcoreapp2.1
 - dotnet test UnitTests/UnitTests.csproj -f netcoreapp3.1
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ env:
   - secure: eCV8oUcxQeRF51JhMjTQ83ikmqCVBBGSbYb3Np7sOvECGfWftVy0m4RB9Swidko45qCV5QPCWJsKXdgZqlBV6sNW7CW3q6zdeSVpSl9RS4a+CC3qpd68xHQqQ8bGppxy67RTkdRL4AkyE24rGdie4VVZCAaIZp4L98BntZYK5Iy9SebVF9QxbL2KKKjKrSpy/SsqjuR2EQlL7T60oCtpbU5dbA1kPijPEFD7BF6zpsQMHCKjZU64AZqJmYFtWc7Y0Bi3kex/XuiO/PYfMDioIgoUnsLMqgx2/koexOkRj4jUoG/rzamRfMSqFLZO8LJkjVjfu9T1gw/nmmRbEjiTsAUh84ixv/o9hft+ngu+qKi6/Jud9DMuEDDeb+ErCWykXuXxfhOyBAuIefCgTuMKZlbNUkgErmJ8psD1kWCYLvLkzlyQ0Pf7R+wuhcbkJcOh2AdXnia+u5vQ1o4n7eKiNmjL7Roqzq/33fWf3ZZu9RK0ZWRbqbM9hNuRu/6y3HlZoGKvp1gZVLC5pJ56uaxdmllzF95+KFnEhOqnu47yF6wgmPMLUPIIsKdwaV71AOwpXT/yTd3DpMTpCJ10yxGtjB6lwOjgCcxKl3JesLKaT61CKLvr8XlJR64VZVfkVEfZdHAjxyyHEUnottKjQlmSSdSfpLBm8JOA+W1AnfIP10M=
   - secure: pgQ5TUQQXzHGCEweNP14I4z6/XI7n3muOQLHsecKF9NQHAUv88eyUDGuyVSretr0rbyBzuxr1lDxTu902fkBrrBqcTXwloSqBfJfnhEbhU02eRXohg1D1LVbnbn4P+Mj73Iv31DCXeM/soHMNgwcczCSIDoZHMAcT8q8Yk/uMLf4QzDBjJCytEb3KuWEUJ30VxPhryBv3wUi+PHa7pZIbAUtkXA9YEBsZbzbIify+/j110cbPyqstYExuYCVdAPAWSyXLmUgonLQKxg6NTwCDySMTMj4oOckHy99YbaBKt3douNevHeNvJ88ZSZ9aQjp0yu/2Pp6DCmCbbIkjFoOH2af2jYaBlTi4faXC3YVmzVXW3xI+cjCPKvXRcf9Eg4F66lURtCwXAJkqRqLC7+ZxPs1q0kb//NAvVPS7caS7k1smzOLLbO/kWFmCaZqprO5v3zccoobv/HNg43LYvj9r0912rsgyEMRV7k76waQD4RAsZlvRyNHthepktptT1TKFW+AVusV4qZVAulBU6b+OHrWGZ489gTTz7YAAirjjEU/qFmNYwfv8i1WWDDzUlUPRlUndf/ylDvFEfCE+P+uOcuGPexYaRjDfi8BQ4HIb2nSwXAaxF2sbPzZuL4xNB9nAVyJhq3GhckHUkHflnvQme5bYBfSKDCDwk9IJCACB/k=
 mono: none
-dotnet: 2.1.2
+dotnet: # Test against LTS versions
+  - 2.1.16 # EOL for 2.1: 2021.08.21
+  - 3.1.2 # EOL for 3.1: 2022.12.03
 script:
 # If this is not a pull request and the commit is tagged, set the package version to the git tag
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n "$TRAVIS_TAG" ]; then PACKAGE_VERSION=$TRAVIS_TAG; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ script:
 - dotnet restore
 - sed -i -e "s/>0.0.0</>$PACKAGE_VERSION</" ./GettyImages.Api/GettyImages.Api.csproj
 - cat ./GettyImages.Api/GettyImages.Api.csproj
-- dotnet build -c Release -f netcoreapp2.1
-- dotnet test UnitTests/UnitTests.csproj
-- dotnet build -c Release -f netcoreapp3.1
-- dotnet test UnitTests/UnitTests.csproj
+- dotnet build -c Release
+- dotnet test UnitTests/UnitTests.csproj -f netcoreapp2.1
+- dotnet test UnitTests/UnitTests.csproj -f netcoreapp3.1
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
   - secure: eCV8oUcxQeRF51JhMjTQ83ikmqCVBBGSbYb3Np7sOvECGfWftVy0m4RB9Swidko45qCV5QPCWJsKXdgZqlBV6sNW7CW3q6zdeSVpSl9RS4a+CC3qpd68xHQqQ8bGppxy67RTkdRL4AkyE24rGdie4VVZCAaIZp4L98BntZYK5Iy9SebVF9QxbL2KKKjKrSpy/SsqjuR2EQlL7T60oCtpbU5dbA1kPijPEFD7BF6zpsQMHCKjZU64AZqJmYFtWc7Y0Bi3kex/XuiO/PYfMDioIgoUnsLMqgx2/koexOkRj4jUoG/rzamRfMSqFLZO8LJkjVjfu9T1gw/nmmRbEjiTsAUh84ixv/o9hft+ngu+qKi6/Jud9DMuEDDeb+ErCWykXuXxfhOyBAuIefCgTuMKZlbNUkgErmJ8psD1kWCYLvLkzlyQ0Pf7R+wuhcbkJcOh2AdXnia+u5vQ1o4n7eKiNmjL7Roqzq/33fWf3ZZu9RK0ZWRbqbM9hNuRu/6y3HlZoGKvp1gZVLC5pJ56uaxdmllzF95+KFnEhOqnu47yF6wgmPMLUPIIsKdwaV71AOwpXT/yTd3DpMTpCJ10yxGtjB6lwOjgCcxKl3JesLKaT61CKLvr8XlJR64VZVfkVEfZdHAjxyyHEUnottKjQlmSSdSfpLBm8JOA+W1AnfIP10M=
   - secure: pgQ5TUQQXzHGCEweNP14I4z6/XI7n3muOQLHsecKF9NQHAUv88eyUDGuyVSretr0rbyBzuxr1lDxTu902fkBrrBqcTXwloSqBfJfnhEbhU02eRXohg1D1LVbnbn4P+Mj73Iv31DCXeM/soHMNgwcczCSIDoZHMAcT8q8Yk/uMLf4QzDBjJCytEb3KuWEUJ30VxPhryBv3wUi+PHa7pZIbAUtkXA9YEBsZbzbIify+/j110cbPyqstYExuYCVdAPAWSyXLmUgonLQKxg6NTwCDySMTMj4oOckHy99YbaBKt3douNevHeNvJ88ZSZ9aQjp0yu/2Pp6DCmCbbIkjFoOH2af2jYaBlTi4faXC3YVmzVXW3xI+cjCPKvXRcf9Eg4F66lURtCwXAJkqRqLC7+ZxPs1q0kb//NAvVPS7caS7k1smzOLLbO/kWFmCaZqprO5v3zccoobv/HNg43LYvj9r0912rsgyEMRV7k76waQD4RAsZlvRyNHthepktptT1TKFW+AVusV4qZVAulBU6b+OHrWGZ489gTTz7YAAirjjEU/qFmNYwfv8i1WWDDzUlUPRlUndf/ylDvFEfCE+P+uOcuGPexYaRjDfi8BQ4HIb2nSwXAaxF2sbPzZuL4xNB9nAVyJhq3GhckHUkHflnvQme5bYBfSKDCDwk9IJCACB/k=
 mono: none
-dotnet: # Test against LTS versions
-  - 2.1.16 # EOL for 2.1: 2021.08.21
-  - 3.1.2 # EOL for 3.1: 2022.12.03
+dotnet: # Test against LTS versions. Version numbers are for SDK
+  - 2.1.804 # EOL for 2.1: 2021.08.21
+  - 3.1.102 # EOL for 3.1: 2022.12.03
 script:
 # If this is not a pull request and the commit is tagged, set the package version to the git tag
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n "$TRAVIS_TAG" ]; then PACKAGE_VERSION=$TRAVIS_TAG; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ script:
 - dotnet restore
 - sed -i -e "s/>0.0.0</>$PACKAGE_VERSION</" ./GettyImages.Api/GettyImages.Api.csproj
 - cat ./GettyImages.Api/GettyImages.Api.csproj
-- dotnet build -c Release
+- dotnet build -c Release -f netcoreapp2.1
+- dotnet test UnitTests/UnitTests.csproj
+- dotnet build -c Release -f netcoreapp3.1
 - dotnet test UnitTests/UnitTests.csproj
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
 mono: none
 dotnet: # Test against LTS versions. Version numbers are for SDK
   - 2.1.804 # EOL for 2.1: 2021.08.21
-  - 3.1.102 # EOL for 3.1: 2022.12.03
+  #- 3.1.102 # EOL for 3.1: 2022.12.03
+before_install:
+  - sudo apt-get install dotnet-sdk-3.1
 script:
 # If this is not a pull request and the commit is tagged, set the package version to the git tag
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n "$TRAVIS_TAG" ]; then PACKAGE_VERSION=$TRAVIS_TAG; fi

--- a/GettyImages.Api/Images/Images.cs
+++ b/GettyImages.Api/Images/Images.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace GettyImages.Api.Images

--- a/GettyImages.Api/Search/SearchImages.cs
+++ b/GettyImages.Api/Search/SearchImages.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http;
 using System.Threading.Tasks;
 using GettyImages.Api.Entity;
 

--- a/GettyImages.Api/Search/SearchVideos.cs
+++ b/GettyImages.Api/Search/SearchVideos.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http;
 using System.Threading.Tasks;
 using GettyImages.Api.Entity;
 

--- a/GettyImages.Api/Videos/Videos.cs
+++ b/GettyImages.Api/Videos/Videos.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace GettyImages.Api.Videos

--- a/UnitTests/HeaderAndBody/HeadersTests.cs
+++ b/UnitTests/HeaderAndBody/HeadersTests.cs
@@ -31,7 +31,7 @@ namespace UnitTests.HeaderAndBody
             {
                 await headerHandler.SendAsync(request, new CancellationToken());
             }
-            catch (System.InvalidOperationException e)
+            catch (System.InvalidOperationException)
             {
                 //No inner handler being assigned to HeadersHandler for test so catch needed for expected exception.
             }

--- a/UnitTests/HeaderAndBody/TestHeadersHandler.cs
+++ b/UnitTests/HeaderAndBody/TestHeadersHandler.cs
@@ -13,7 +13,7 @@ namespace UnitTests.HeaderAndBody
         {
         }
    
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        public new async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return await base.SendAsync(request, cancellationToken);
         }

--- a/UnitTests/Search/SearchImagesTests.cs
+++ b/UnitTests/Search/SearchImagesTests.cs
@@ -397,8 +397,6 @@ namespace UnitTests.Search
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var x = SortOrder.Newest;
-
             var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
                 .WithPhrase("cat").WithSortOrder(SortOrder.Newest).ExecuteAsync().Result;
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Update the tests to run against the currently supported dotnet core versions: 2.1 and 3.1. Also got rid of build warnings.

Testing against multiple frameworks involves a bit of non-intuitive tweaking in the Travis YAML file and the unit test project file. Comments have been added to the Travis YAML file to document the required steps.