### PR TITLE
Make tests async

### DIFF
--- a/GettyImages.Api/ApiClient.cs
+++ b/GettyImages.Api/ApiClient.cs
@@ -61,10 +61,6 @@ namespace GettyImages.Api
             return new ApiClient(apiKey, apiSecret, refreshToken, DefaultApiUri, null);
         }
 
-
-
-
-
         public static ApiClient GetApiClientWithClientCredentials(string apiKey, string apiSecret,
             string baseUrl)
         {
@@ -83,7 +79,6 @@ namespace GettyImages.Api
         {
             return new ApiClient(apiKey, apiSecret, refreshToken, baseUrl, null);
         }
-
 
         public static ApiClient GetApiClientWithClientCredentials(string apiKey, string apiSecret, DelegatingHandler customHandler)
         {

--- a/GettyImages.Api/ApiRequest.cs
+++ b/GettyImages.Api/ApiRequest.cs
@@ -34,13 +34,13 @@ namespace GettyImages.Api
             switch (Method)
             {
                 case "GET":
-                    return helper.Get(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters));
+                    return helper.GetAsync(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters));
                 case "POST":
-                    return helper.PostQuery(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters), BuildBody(BodyParameter));
+                    return helper.PostQueryAsync(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters), BuildBody(BodyParameter));
                 case "PUT":
-                    return helper.PutQuery(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters), BuildBody(BodyParameter));
+                    return helper.PutQueryAsync(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters), BuildBody(BodyParameter));
                 case "DELETE":
-                    return helper.DeleteQuery(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters));
+                    return helper.DeleteQueryAsync(BuildQuery(QueryParameters), Path, BuildHeaders(HeaderParameters));
                 default:
                     throw new SdkException("No appropriate HTTP method found for this request.");
             }

--- a/GettyImages.Api/ApiRequest.cs
+++ b/GettyImages.Api/ApiRequest.cs
@@ -21,14 +21,11 @@ namespace GettyImages.Api
         protected internal IDictionary<string, object> HeaderParameters;
         protected internal string BodyParameter;
 
-        protected string AssetFamily;
-
-        public ApiRequest(DelegatingHandler customHandler)
+        protected ApiRequest(DelegatingHandler customHandler)
         {
             _customHandler = customHandler;
             QueryParameters = new Dictionary<string, object>();
             HeaderParameters = new Dictionary<string, object>();
-
         }
 
         public virtual Task<dynamic> ExecuteAsync()

--- a/GettyImages.Api/AssetRegistration/AssetRegistrations.cs
+++ b/GettyImages.Api/AssetRegistration/AssetRegistrations.cs
@@ -26,7 +26,6 @@ namespace GettyImages.Api.AssetRegistration
             return await base.ExecuteAsync();
         }
 
-
         public AssetRegistrations WithRequest(string value)
         {
             BodyParameter = value;

--- a/GettyImages.Api/Boards/DeleteAssets.cs
+++ b/GettyImages.Api/Boards/DeleteAssets.cs
@@ -6,7 +6,6 @@ namespace GettyImages.Api.Boards
 {
     public class DeleteAssets : ApiRequest
     {
-
         protected const string V3DeleteAssetsPath = "/boards/{0}/assets";
         protected string BoardId { get; set; }
 

--- a/GettyImages.Api/Credentials.cs
+++ b/GettyImages.Api/Credentials.cs
@@ -19,7 +19,6 @@ namespace GettyImages.Api
         private readonly string _baseUrl;
         private Token _accessToken;
 
-
         internal Credentials(string apiKey, string apiSecret, string baseUrl)
         {
             _baseUrl = baseUrl;
@@ -123,10 +122,12 @@ namespace GettyImages.Api
 
         internal async Task<Token> GetAccessToken()
         {
-            if (CredentialType != CredentialType.ClientCredentials && CredentialType != CredentialType.ResourceOwner &&
-                CredentialType != CredentialType.RefreshToken
+            if ((CredentialType != CredentialType.ClientCredentials && 
+                CredentialType != CredentialType.ResourceOwner &&
+                CredentialType != CredentialType.RefreshToken)
                 ||
-                (_accessToken != null && _accessToken.Expiration >= DateTime.UtcNow.AddMinutes(-5)))
+                (_accessToken != null && 
+                 _accessToken.Expiration >= DateTime.UtcNow.AddMinutes(-5)))
             {
                 return _accessToken;
             }

--- a/GettyImages.Api/Credentials.cs
+++ b/GettyImages.Api/Credentials.cs
@@ -133,7 +133,7 @@ namespace GettyImages.Api
             }
 
             var helper = new WebHelper(this, _baseUrl, null);
-            var response = await helper.PostForm(GetCredentialsDictionary(), Oauth2TokenPath, null, null, false);
+            var response = await helper.PostFormAsync(GetCredentialsDictionary(), Oauth2TokenPath, null, null, false);
             _accessToken = new Token
             {
                 AccessToken = response.access_token.ToString(),

--- a/GettyImages.Api/Entity/EditorialSegment.cs
+++ b/GettyImages.Api/Entity/EditorialSegment.cs
@@ -5,7 +5,6 @@ namespace GettyImages.Api.Entity
     [Flags]
     public enum EditorialSegment
     {
-        
         None = 0,
         Archival = 1,
         Entertainment = 2,

--- a/GettyImages.Api/Handlers/UserAgentHandler.cs
+++ b/GettyImages.Api/Handlers/UserAgentHandler.cs
@@ -63,6 +63,5 @@ namespace GettyImages.Api.Handlers
             }
             return base.SendAsync(request, cancellationToken);
         }
-
     }
 }

--- a/GettyImages.Api/Orders/Orders.cs
+++ b/GettyImages.Api/Orders/Orders.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace GettyImages.Api.Orders
@@ -41,4 +40,3 @@ namespace GettyImages.Api.Orders
         }
     }
 }
-

--- a/GettyImages.Api/SdkException.cs
+++ b/GettyImages.Api/SdkException.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace GettyImages.Api
@@ -26,11 +27,11 @@ namespace GettyImages.Api
 
         public HttpStatusCode? StatusCode { get; set; }
 
-        internal static void GenerateSdkException(HttpResponseMessage httpResponse, string message = null)
+        internal static async Task GenerateSdkException(HttpResponseMessage httpResponse, string message = null)
         {
             if (string.IsNullOrEmpty(message))
             {
-                var resultContentAsString = httpResponse.Content.ReadAsStringAsync().Result;
+                var resultContentAsString = await httpResponse.Content.ReadAsStringAsync();
 
                 if (httpResponse.Content.Headers != null && httpResponse.Content.Headers.ContentType != null && httpResponse.Content.Headers.ContentType.MediaType == "application/json")
                 {   

--- a/GettyImages.Api/SdkException.cs
+++ b/GettyImages.Api/SdkException.cs
@@ -27,7 +27,7 @@ namespace GettyImages.Api
 
         public HttpStatusCode? StatusCode { get; set; }
 
-        internal static async Task GenerateSdkException(HttpResponseMessage httpResponse, string message = null)
+        internal static async Task GenerateSdkExceptionAsync(HttpResponseMessage httpResponse, string message = null)
         {
             if (string.IsNullOrEmpty(message))
             {

--- a/GettyImages.Api/Search/SearchImages.cs
+++ b/GettyImages.Api/Search/SearchImages.cs
@@ -7,13 +7,10 @@ namespace GettyImages.Api.Search
 {
     public class SearchImages : ApiRequest
     {
-        private readonly DelegatingHandler _customHandler;
-        protected const string V3SearchImagesPath = "/search/images";
-
+        private const string V3SearchImagesPath = "/search/images";
 
         private SearchImages(Credentials credentials, string baseUrl, DelegatingHandler customHandler) : base(customHandler)
         {
-            _customHandler = customHandler;
             Credentials = credentials;
             BaseUrl = baseUrl;
         }

--- a/GettyImages.Api/Search/SearchImagesCreative.cs
+++ b/GettyImages.Api/Search/SearchImagesCreative.cs
@@ -100,7 +100,6 @@ namespace GettyImages.Api.Search
             return this;
         }
 
-
         public SearchImagesCreative WithResponseFields(IEnumerable<string> values)
         {
             AddResponseFields(values);

--- a/GettyImages.Api/Search/SearchImagesCreativeByImage.cs
+++ b/GettyImages.Api/Search/SearchImagesCreativeByImage.cs
@@ -44,7 +44,7 @@ namespace GettyImages.Api.Search
         public SearchImagesCreativeByImage AddToBucketAndSearch(string imageFilepath)
         {
             var url = AddToBucket(imageFilepath);
-            this.WithImageUrl(url);
+            WithImageUrl(url);
             return this;
         }
 

--- a/GettyImages.Api/WebHelper.cs
+++ b/GettyImages.Api/WebHelper.cs
@@ -22,10 +22,10 @@ namespace GettyImages.Api
             _customHandler = customHandler;
         }
 
-        internal async Task<dynamic> Get(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
+        internal async Task<dynamic> GetAsync(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
             IEnumerable<KeyValuePair<string, string>> headerParameters = null)
         {
-            using (var client = new HttpClient(await GetHandlers(headerParameters)))
+            using (var client = new HttpClient(await GetHandlersAsync(headerParameters)))
             {
                 var uri = _baseAddress + path;
                 var builder = new UriBuilder(uri)
@@ -44,21 +44,21 @@ namespace GettyImages.Api
 
                 try
                 {
-                    return await HandleResponse(httpResponse);
+                    return await HandleResponseAsync(httpResponse);
                 }
                 catch (UnauthorizedException)
                 {
                     _credentials.ResetAccessToken();
-                    using (var retryClient = new HttpClient(await GetHandlers(headerParameters)))
+                    using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
                         httpResponse = await retryClient.GetAsync(builder.Uri);
-                        return await HandleResponse(httpResponse);
+                        return await HandleResponseAsync(httpResponse);
                     }
                 }
             }
         }
 
-        internal async Task<dynamic> PostForm(
+        internal async Task<dynamic> PostFormAsync(
             IEnumerable<KeyValuePair<string, string>> formParameters,
             string path, DelegatingHandler handlers, IEnumerable<KeyValuePair<string, string>> headerParameters = null, bool shouldRetry = true)
         {
@@ -79,17 +79,17 @@ namespace GettyImages.Api
 
                 try
                 {
-                    return await HandleResponse(httpResponse);
+                    return await HandleResponseAsync(httpResponse);
                 }
                 catch (UnauthorizedException)
                 {
                     if (shouldRetry)
                     {
                         _credentials.ResetAccessToken();
-                        using (var retryClient = new HttpClient(await GetHandlers(headerParameters)))
+                        using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                         {
                             httpResponse = await retryClient.PostAsync(uri, new FormUrlEncodedContent(formParameters));
-                            return await HandleResponse(httpResponse);
+                            return await HandleResponseAsync(httpResponse);
                         }
                     }
                     throw;
@@ -97,10 +97,10 @@ namespace GettyImages.Api
             }
         }
 
-        internal async Task<dynamic> PostQuery(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
+        internal async Task<dynamic> PostQueryAsync(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
             IEnumerable<KeyValuePair<string, string>> headerParameters, HttpContent bodyParameter)
         {
-            using (var client = new HttpClient(await GetHandlers(headerParameters)))
+            using (var client = new HttpClient(await GetHandlersAsync(headerParameters)))
             {
                 var uri = _baseAddress + path;
                 var requestUri = new UriBuilder(uri) { Query = BuildQuery(queryParameters) }.Uri;
@@ -115,24 +115,24 @@ namespace GettyImages.Api
 
                 try
                 {
-                    return await HandleResponse(httpResponse);
+                    return await HandleResponseAsync(httpResponse);
                 }
                 catch (UnauthorizedException)
                 {
                     _credentials.ResetAccessToken();
-                    using (var retryClient = new HttpClient(await GetHandlers(headerParameters)))
+                    using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
                         httpResponse = await retryClient.PostAsync(uri, new FormUrlEncodedContent(queryParameters));
-                        return await HandleResponse(httpResponse);
+                        return await HandleResponseAsync(httpResponse);
                     }
                 }
             }
         }
 
-        internal async Task<dynamic> PutQuery(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
+        internal async Task<dynamic> PutQueryAsync(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
             IEnumerable<KeyValuePair<string, string>> headerParameters, HttpContent bodyParameter)
         {
-            using (var client = new HttpClient(await GetHandlers(headerParameters)))
+            using (var client = new HttpClient(await GetHandlersAsync(headerParameters)))
             {
                 var uri = _baseAddress + path;
                 var requestUri = new UriBuilder(uri) { Query = BuildQuery(queryParameters) }.Uri;
@@ -147,24 +147,24 @@ namespace GettyImages.Api
 
                 try
                 {
-                    return await HandleResponse(httpResponse);
+                    return await HandleResponseAsync(httpResponse);
                 }
                 catch (UnauthorizedException)
                 {
                     _credentials.ResetAccessToken();
-                    using (var retryClient = new HttpClient(await GetHandlers(headerParameters)))
+                    using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
                         httpResponse = await retryClient.PutAsync(uri, new FormUrlEncodedContent(queryParameters));
-                        return await HandleResponse(httpResponse);
+                        return await HandleResponseAsync(httpResponse);
                     }
                 }
             }
         }
 
-        internal async Task<dynamic> DeleteQuery(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
+        internal async Task<dynamic> DeleteQueryAsync(IEnumerable<KeyValuePair<string, string>> queryParameters, string path,
             IEnumerable<KeyValuePair<string, string>> headerParameters = null)
         {
-            using (var client = new HttpClient(await GetHandlers(headerParameters)))
+            using (var client = new HttpClient(await GetHandlersAsync(headerParameters)))
             {
                 var uri = _baseAddress + path;
                 var builder = new UriBuilder(uri)
@@ -183,21 +183,21 @@ namespace GettyImages.Api
 
                 try
                 {
-                    return await HandleResponse(httpResponse);
+                    return await HandleResponseAsync(httpResponse);
                 }
                 catch (UnauthorizedException)
                 {
                     _credentials.ResetAccessToken();
-                    using (var retryClient = new HttpClient(await GetHandlers(headerParameters)))
+                    using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
                         httpResponse = await retryClient.DeleteAsync(builder.Uri);
-                        return await HandleResponse(httpResponse);
+                        return await HandleResponseAsync(httpResponse);
                     }
                 }
             }
         }
 
-        private async Task<DelegatingHandler> GetHandlers(
+        private async Task<DelegatingHandler> GetHandlersAsync(
             IEnumerable<KeyValuePair<string, string>> headerParameters = null)
         {
             if (_customHandler != null)
@@ -218,7 +218,7 @@ namespace GettyImages.Api
             return mainHandler;
         }
 
-        private static async Task<dynamic> HandleResponse(HttpResponseMessage httpResponse)
+        private static async Task<dynamic> HandleResponseAsync(HttpResponseMessage httpResponse)
         {
             if (httpResponse.IsSuccessStatusCode)
             {
@@ -226,7 +226,7 @@ namespace GettyImages.Api
             }
             else
             {
-                await SdkException.GenerateSdkException(httpResponse);
+                await SdkException.GenerateSdkExceptionAsync(httpResponse);
                 return null;
             }
         }

--- a/GettyImages.Api/WebHelper.cs
+++ b/GettyImages.Api/WebHelper.cs
@@ -218,12 +218,6 @@ namespace GettyImages.Api
             return mainHandler;
         }
 
-        internal async Task<dynamic> PostForm(IEnumerable<KeyValuePair<string, string>> formParameters, string path)
-        {
-            var handlers = await GetHandlers();
-            return PostForm(formParameters, path, handlers);
-        }
-
         private static async Task<dynamic> HandleResponse(HttpResponseMessage httpResponse)
         {
             if (httpResponse.IsSuccessStatusCode)
@@ -232,7 +226,7 @@ namespace GettyImages.Api
             }
             else
             {
-                SdkException.GenerateSdkException(httpResponse);
+                await SdkException.GenerateSdkException(httpResponse);
                 return null;
             }
         }

--- a/UnitTests/Artists/ArtistsImagesTests.cs
+++ b/UnitTests/Artists/ArtistsImagesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,25 +9,25 @@ namespace UnitTests.Artists
     public class ArtistsImagesTests
     {
         [Fact]
-        public void SearchForImagesByArtistBasic()
+        public async Task SearchForImagesByArtistBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages().WithArtist("roman makhmutov").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages().WithArtist("roman makhmutov").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
         }
 
         [Fact]
-        public void SearchForImagesByArtistWithFields()
+        public async Task SearchForImagesByArtistWithFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() {"asset_family", "keywords"};
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
-                .WithArtist("roman makhmutov").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
+                .WithArtist("roman makhmutov").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
@@ -34,12 +35,12 @@ namespace UnitTests.Artists
         }
 
         [Fact]
-        public void SearchForImagesByArtistWithPage()
+        public async Task SearchForImagesByArtistWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
-                .WithArtist("roman makhmutov").WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
+                .WithArtist("roman makhmutov").WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
@@ -47,12 +48,12 @@ namespace UnitTests.Artists
         }
 
         [Fact]
-        public void SearchForImagesByArtistWithPageSize()
+        public async Task SearchForImagesByArtistWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
-                .WithArtist("roman makhmutov").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsImages()
+                .WithArtist("roman makhmutov").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");

--- a/UnitTests/Artists/ArtistsVideosTests.cs
+++ b/UnitTests/Artists/ArtistsVideosTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,25 +9,25 @@ namespace UnitTests.Artists
     public class ArtistsVideosTests
     {
         [Fact]
-        public void SearchForVideosByArtistBasic()
+        public async Task SearchForVideosByArtistBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos().WithArtist("roman makhmutov").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos().WithArtist("roman makhmutov").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
         }
 
         [Fact]
-        public void SearchForVideosByArtistWithFields()
+        public async Task SearchForVideosByArtistWithFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "keywords" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
-                .WithArtist("roman makhmutov").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
+                .WithArtist("roman makhmutov").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
@@ -34,12 +35,12 @@ namespace UnitTests.Artists
         }
 
         [Fact]
-        public void SearchForVideosByArtistWithPage()
+        public async Task SearchForVideosByArtistWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
-                .WithArtist("roman makhmutov").WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
+                .WithArtist("roman makhmutov").WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");
@@ -47,12 +48,12 @@ namespace UnitTests.Artists
         }
 
         [Fact]
-        public void SearchForVideosByArtistWithPageSize()
+        public async Task SearchForVideosByArtistWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
-                .WithArtist("roman makhmutov").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ArtistsVideos()
+                .WithArtist("roman makhmutov").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artists/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("artist_name=roman+makhmutov");

--- a/UnitTests/AssetChanges/ChangeSetsTests.cs
+++ b/UnitTests/AssetChanges/ChangeSetsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,26 +8,27 @@ namespace UnitTests.AssetChanges
     public class ChangeSetsTests
     {
         [Fact]
-        public void ChangeSetsBasic()
+        public async Task ChangeSetsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .ChangeSets().WithChannelId(155432).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .ChangeSets().WithChannelId(155432).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset-changes/change-sets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("channel_id=155432");
         }
 
-        public void ChangeSetsWithBatchSize()
+        [Fact]
+        public async Task ChangeSetsWithBatchSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ChangeSets()
-                .WithChannelId(155432).WithBatchSize(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).ChangeSets()
+                .WithChannelId(155432).WithBatchSize(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset-changes/change-sets");
-            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("batch_size=155432");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("batch_size=200");
         }
     }
 }

--- a/UnitTests/AssetChanges/ChannelsTests.cs
+++ b/UnitTests/AssetChanges/ChannelsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.AssetChanges
     public class ChannelsTests
     {
         [Fact]
-        public void ChannelsBasic()
+        public async Task ChannelsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Channels().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Channels().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset-changes/channels");
         }

--- a/UnitTests/AssetChanges/DeleteAssetChangesTests.cs
+++ b/UnitTests/AssetChanges/DeleteAssetChangesTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.AssetChanges
     public class DeleteAssetChangesTests
     {
         [Fact]
-        public void DeleteAssetChangesBasic()
+        public async Task DeleteAssetChangesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .DeleteAssetChanges().WithChangeSetId(155432).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DeleteAssetChanges().WithChangeSetId(155432).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset-changes/change-sets/155432");
         }

--- a/UnitTests/AssetLicensing/AcquireExtendedLicenseTests.cs
+++ b/UnitTests/AssetLicensing/AcquireExtendedLicenseTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace UnitTests.AssetLicensing
     public class AcquireExtendedLicenseTests
     {
         [Fact]
-        public void AcquireExtendedLicenseBasic()
+        public async Task AcquireExtendedLicenseBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
             var requestBody = @"{
@@ -16,15 +17,15 @@ namespace UnitTests.AssetLicensing
                                 }";
 
             var assetId = "123";
-            var response = ApiClient.GetApiClientWithResourceOwnerCredentials("apiKey", "apiSecret", "userName", "userPassword",  testHandler)
+            await ApiClient.GetApiClientWithResourceOwnerCredentials("apiKey", "apiSecret", "userName", "userPassword",  testHandler)
                 .AcquireExtendedLicense()
                 .WithAssetId(assetId)
                 .WithExtendedLicenses(requestBody)
-                .ExecuteAsync()
-                .Result;
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain(string.Format("/asset-licensing/{0}", assetId));
-            testHandler.Request.Content.ReadAsStringAsync().Result.Should().Contain(requestBody);
+            var content = await testHandler.Request.Content.ReadAsStringAsync();
+            content.Should().Contain(requestBody);
         }
     }
 }

--- a/UnitTests/AssetRegristration/AssestRegistrationsTests.cs
+++ b/UnitTests/AssetRegristration/AssestRegistrationsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,7 +8,7 @@ namespace UnitTests.AssetRegristration
     public class AssestRegistrationsTests
     {
         [Fact]
-        public void AssetRegistrationsBasic()
+        public async Task AssetRegistrationsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -18,9 +18,8 @@ namespace UnitTests.AssetRegristration
                 ]
             }";
 
-            List<string> ids = new List<string>();
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .AssetRegistrations().WithRequest(request).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .AssetRegistrations().WithRequest(request).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset-registrations");
         }

--- a/UnitTests/Boards/DeleteAssetsByIdTests.cs
+++ b/UnitTests/Boards/DeleteAssetsByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class DeleteAssetsByIdTests
     {
         [Fact]
-        public void DeleteAssetsByIdBasic()
+        public async Task DeleteAssetsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .DeleteAssetsById().WithBoardId("15345").WithAssetId("1245").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DeleteAssetsById().WithBoardId("15345").WithAssetId("1245").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/assets/1245");
         }

--- a/UnitTests/Boards/DeleteAssetsTests.cs
+++ b/UnitTests/Boards/DeleteAssetsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,14 +9,14 @@ namespace UnitTests.Boards
     public class DeleteAssetsTests
     {
         [Fact]
-        public void DeleteAssetsBasic()
+        public async Task DeleteAssetsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<string> {"1234", "12553"};
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .DeleteAssets().WithBoardId("15345").WithAssetIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DeleteAssets().WithBoardId("15345").WithAssetIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/assets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("asset_ids=1234%2C12553");

--- a/UnitTests/Boards/DeleteBoardByIdTests.cs
+++ b/UnitTests/Boards/DeleteBoardByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class DeleteBoardByIdTests
     {
         [Fact]
-        public void DeleteBoardsByIdBasic()
+        public async Task DeleteBoardsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .DeleteBoardsById().WithBoardId("15345").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DeleteBoardsById().WithBoardId("15345").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345");
         }

--- a/UnitTests/Boards/DeleteCommentsByIdTests.cs
+++ b/UnitTests/Boards/DeleteCommentsByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class DeleteCommentsByIdTests
     {
         [Fact]
-        public void DeleteCommentsByIdBasic()
+        public async Task DeleteCommentsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .DeleteCommentsById().WithBoardId("15345").WithCommentId("1245").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DeleteCommentsById().WithBoardId("15345").WithCommentId("1245").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/comments/1245");
         }

--- a/UnitTests/Boards/GetBoardsByIdTests.cs
+++ b/UnitTests/Boards/GetBoardsByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class GetBoardsByIdTests
     {
         [Fact]
-        public void GetBoardsByIdBasic()
+        public async Task GetBoardsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoardsById().WithBoardId("15345").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoardsById().WithBoardId("15345").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345");
         }

--- a/UnitTests/Boards/GetBoardsTests.cs
+++ b/UnitTests/Boards/GetBoardsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
 using Xunit;
@@ -8,59 +9,59 @@ namespace UnitTests.Boards
     public class GetBoardsTests
     { 
         [Fact]
-        public void GetBoardsBasic()
+        public async Task GetBoardsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoards().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoards().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
         }
 
         [Fact]
-        public void GetBoardsWithBoardRelationship()
+        public async Task GetBoardsWithBoardRelationship()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoards().WithBoardRelationship(BoardRelationship.Invited).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoards().WithBoardRelationship(BoardRelationship.Invited).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("board_relationship=invited");
         }
 
         [Fact]
-        public void GetBoardsWithPage()
+        public async Task GetBoardsWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoards().WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoards().WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=3");
         }
 
         [Fact]
-        public void GetBoardsWithPageSize()
+        public async Task GetBoardsWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoards().WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoards().WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");
         }
 
         [Fact]
-        public void GetBoardsWithSortOrder()
+        public async Task GetBoardsWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetBoards().WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetBoards().WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("sort_order=best_match");

--- a/UnitTests/Boards/GetCommentsTests.cs
+++ b/UnitTests/Boards/GetCommentsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class GetCommentsTests
     {
         [Fact]
-        public void GetCommentsBasic()
+        public async Task GetCommentsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .GetComments().WithBoardId("15345").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .GetComments().WithBoardId("15345").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/comments");
         }

--- a/UnitTests/Boards/PostBoardsTests.cs
+++ b/UnitTests/Boards/PostBoardsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace UnitTests.Boards
     public class PostBoardsTests
     {
         [Fact]
-        public void PostBoardsBasic()
+        public async Task PostBoardsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -15,8 +16,8 @@ namespace UnitTests.Boards
                 'name': 'string',
                 'description': 'string'
             }";
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PostBoards().WithNewBoard(newboard).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PostBoards().WithNewBoard(newboard).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards");
         }

--- a/UnitTests/Boards/PostCommentsTests.cs
+++ b/UnitTests/Boards/PostCommentsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace UnitTests.Boards
     public class PostCommentsTests
     {
         [Fact]
-        public void PostCommentsBasic()
+        public async Task PostCommentsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -15,8 +16,8 @@ namespace UnitTests.Boards
                 'text': 'string'
              }";
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PostComments().WithBoardId("15345").WithComment(comment).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PostComments().WithBoardId("15345").WithComment(comment).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/comments");
         }

--- a/UnitTests/Boards/PutAssetsByIdTests.cs
+++ b/UnitTests/Boards/PutAssetsByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class PutAssetsByIdTests
     {
         [Fact]
-        public void PutAssetsByIdBasic()
+        public async Task PutAssetsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PutAssetsById().WithBoardId("15345").WithAssetId("1245").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PutAssetsById().WithBoardId("15345").WithAssetId("1245").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/assets/1245");
         }

--- a/UnitTests/Boards/PutAssetsTests.cs
+++ b/UnitTests/Boards/PutAssetsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace UnitTests.Boards
     public class PutAssetsTests
     {
         [Fact]
-        public void PutAssetsBasic()
+        public async Task PutAssetsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -16,8 +17,8 @@ namespace UnitTests.Boards
                 'asset_id': 'string'
              }
              ]";
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PutAssets().WithBoardId("15345").WithBoardAssets(assets).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PutAssets().WithBoardId("15345").WithBoardAssets(assets).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345/assets");
         }

--- a/UnitTests/Boards/PutBoardsByIdTests.cs
+++ b/UnitTests/Boards/PutBoardsByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Boards
     public class PutBoardsByIdTests
     {
         [Fact]
-        public void PutBoardsByIdBasic()
+        public async Task PutBoardsByIdBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PutBoardsById().WithBoardId("15345").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PutBoardsById().WithBoardId("15345").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("boards/15345");
         }

--- a/UnitTests/Collections/CollectionsTests.cs
+++ b/UnitTests/Collections/CollectionsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,13 @@ namespace UnitTests.Collections
     public class CollectionsTests
     {
         [Fact]
-        public void CollectionsBasic()
+        public async Task CollectionsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Collections()
-                .ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Collections()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("collections");
         }

--- a/UnitTests/Countries/CountriesTests.cs
+++ b/UnitTests/Countries/CountriesTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,13 @@ namespace UnitTests.Countries
     public class CollectionsTests
     {
         [Fact]
-        public void CountriesBasic()
+        public async Task CountriesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Countries()
-                .ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Countries()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("countries");
         }

--- a/UnitTests/Customers/CustomersTests.cs
+++ b/UnitTests/Customers/CustomersTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,14 +8,13 @@ namespace UnitTests.Customers
     public class CustomersTests
     {
         [Fact]
-        public void GetCustomerInfoBasic()
+        public async Task GetCustomerInfoBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithResourceOwnerCredentials("apiKey", "apiSecret", "userName", "userPassword", testHandler)
+            await ApiClient.GetApiClientWithResourceOwnerCredentials("apiKey", "apiSecret", "userName", "userPassword", testHandler)
                                     .Customers()
-                                    .ExecuteAsync()
-                                    .Result;
+                                    .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("/customers/current");
         }

--- a/UnitTests/Downloads/DownloadImagesTests.cs
+++ b/UnitTests/Downloads/DownloadImagesTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
 using Xunit;
@@ -7,66 +8,89 @@ namespace UnitTests.Downloads
 {
     public class DownloadImagesTests
     {
-
         [Fact]
-        public void DownloadImagesBasic()
+        public async Task DownloadImagesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
         }
 
         [Fact]
-        public void DownloadImagesWithAutoDownload()
+        public async Task DownloadImagesWithAutoDownload()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").WithAutoDownload().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .WithAutoDownload()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("auto_download=True");
         }
 
         [Fact]
-        public void DownloadImagesWithFileType()
+        public async Task DownloadImagesWithFileType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").WithFileType(FileType.Jpg).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .WithFileType(FileType.Jpg)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("file_type=jpg");
         }
 
         [Fact]
-        public void DownloadImagesWithHeight()
+        public async Task DownloadImagesWithHeight()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").WithHeight(592).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .WithHeight(592)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("height=592");
         }
 
         [Fact]
-        public void DownloadImagesProductId()
+        public async Task DownloadImagesProductId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").WithProductId(592).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .WithProductId(592)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_id=592");
         }
 
         [Fact]
-        public void DownloadImagesWithProductType()
+        public async Task DownloadImagesWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsImages().WithId("464423888").WithProductType(ProductType.Easyaccess).WithHeight(592).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsImages()
+                .WithId("464423888")
+                .WithProductType(ProductType.Easyaccess)
+                .WithHeight(592)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/images/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_type=easyaccess");

--- a/UnitTests/Downloads/DownloadVideosTests.cs
+++ b/UnitTests/Downloads/DownloadVideosTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -6,46 +7,58 @@ namespace UnitTests.Downloads
 {
     public class DownloadVideosTests
     {
-
         [Fact]
-        public void DownloadVideosBasic()
+        public async Task DownloadVideosBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsVideos()
-                .WithId("681332124").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsVideos()
+                .WithId("681332124")
+                .ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/videos/681332124");
         }
 
         [Fact]
-        public void DownloadVidoesWithAutoDownload()
+        public async Task DownloadVideosWithAutoDownload()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsVideos().WithId("464423888").WithAutoDownload().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsVideos()
+                .WithId("464423888")
+                .WithAutoDownload()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/videos/464423888");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("auto_download=True");
         }
 
         [Fact]
-        public void DownloadVideosProductId()
+        public async Task DownloadVideosProductId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsVideos().WithId("681332124").WithProductId(592).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsVideos()
+                .WithId("681332124")
+                .WithProductId(592)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/videos/681332124");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_id=592");
         }
 
         [Fact]
-        public void DownloadVideosWithSize()
+        public async Task DownloadVideosWithSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).DownloadsVideos()
-                .WithId("681332124").WithSize("hd1").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .DownloadsVideos()
+                .WithId("681332124")
+                .WithSize("hd1")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads/videos/681332124");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("size=hd1");

--- a/UnitTests/Downloads/DownloadsTests.cs
+++ b/UnitTests/Downloads/DownloadsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
 using Xunit;
@@ -7,94 +8,110 @@ namespace UnitTests.Downloads
 {
     public class DownloadsTests
     {
-
         [Fact]
-        public void DownloadsBasic()
+        public async Task DownloadsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
         }
 
         [Fact]
-        public void DownloadsWithCompanyDownloads()
+        public async Task DownloadsWithCompanyDownloads()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads().WithCompanyDownloads().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithCompanyDownloads()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("company_downloads=True");
         }
 
         [Fact]
-        public void DownloadsWithEndDate()
+        public async Task DownloadsWithEndDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads().WithEndDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithEndDate("2015-04-01")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("end_date=2015-04-01");
         }
 
         [Fact]
-        public void DownloadsWithPage()
+        public async Task DownloadsWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
-                .WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
+                .WithPage(2)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=2");
         }
 
         [Fact]
-        public void DownloadsWithPageSize()
+        public async Task DownloadsWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
-                .WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithPageSize(50)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");
         }
 
         [Fact]
-        public void DownloadsWithProductType()
+        public async Task DownloadsWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
-                .WithProductType(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithProductType(ProductType.Easyaccess)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_type=easyaccess");
         }
 
-
         [Fact]
-        public void DownloadsWithStartDate()
+        public async Task DownloadsWithStartDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
-                .WithStartDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithStartDate("2015-04-01")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");
         }
 
         [Fact]
-        public void DownloadsWithStartDateAndUseTime()
+        public async Task DownloadsWithStartDateAndUseTime()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Downloads()
-               .WithStartDate("2015-04-01").WithUseTime("true").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Downloads()
+                .WithStartDate("2015-04-01")
+                .WithUseTime("true")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");

--- a/UnitTests/Events/EventsTests.cs
+++ b/UnitTests/Events/EventsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,32 +9,36 @@ namespace UnitTests.Events
     public class EventsTests
     {
         [Fact]
-        public void MultipleEventsBasic()
+        public async Task MultipleEventsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 518451, 518452 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Events().WithIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Events()
+                .WithIds(ids)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=518451%2C518452");
         }
 
         [Fact]
-        public void SingleEventBasic()
+        public async Task SingleEventBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Events().WithId(518451).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Events()
+                .WithId(518451)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("events/518451");
         }
 
         [Fact]
-        public void MultileEventsWithResponseFields()
+        public async Task MultipleEventsWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -41,8 +46,11 @@ namespace UnitTests.Events
 
             var fields = new List<string>() { "id", "image_count" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Events().WithIds(ids).WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Events()
+                .WithIds(ids)
+                .WithResponseFields(fields)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=518451%2C518452");
@@ -50,18 +58,20 @@ namespace UnitTests.Events
         }
 
         [Fact]
-        public void SingleEventWithResponseFields()
+        public async Task SingleEventWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "id", "image_count" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Events().WithId(518451).WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Events()
+                .WithId(518451)
+                .WithResponseFields(fields)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("events/518451");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=id%2Cimage_count");
         }
-
     }
 }

--- a/UnitTests/HeaderAndBody/BodyTests.cs
+++ b/UnitTests/HeaderAndBody/BodyTests.cs
@@ -1,4 +1,5 @@
-﻿using GettyImages.Api;
+﻿using System.Threading.Tasks;
+using GettyImages.Api;
 using GettyImages.Api.Boards;
 using Xunit;
 
@@ -25,7 +26,7 @@ namespace UnitTests.HeaderAndBody
         }
 
         [Fact]
-        public void BodyBuilderTest()
+        public async Task BodyBuilderTest()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -35,8 +36,8 @@ namespace UnitTests.HeaderAndBody
              }
              ]";
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PutAssets().WithBoardId("15345").WithBoardAssets(assets).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PutAssets().WithBoardId("15345").WithBoardAssets(assets).ExecuteAsync();
 
             Assert.Equal("application/json", testHandler.Request.Content.Headers.ContentType.ToString());
         }

--- a/UnitTests/HeaderAndBody/TestHeadersHandler.cs
+++ b/UnitTests/HeaderAndBody/TestHeadersHandler.cs
@@ -8,7 +8,6 @@ namespace UnitTests.HeaderAndBody
 {
     internal class TestHeadersHandler : HeadersHandler
     {
-
         public  TestHeadersHandler(IEnumerable<KeyValuePair<string, string>> headerParameters) : base(headerParameters)
         {
         }

--- a/UnitTests/Images/ImagesDownloadHistoryTests.cs
+++ b/UnitTests/Images/ImagesDownloadHistoryTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,24 +8,24 @@ namespace UnitTests.Images
     public class ImagesDownloadHistoryTests
     {
         [Fact]
-        public void ImageDownloadHistoryWithCompanyDownloads()
+        public async Task ImageDownloadHistoryWithCompanyDownloads()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-               .ImageDownloadHistory().WithId("882449540").WithCompanyDownloads().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+               .ImageDownloadHistory().WithId("882449540").WithCompanyDownloads().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/downloadhistory");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("company_downloads=True");
         }
 
         [Fact]
-        public void DownloadHistoryForImage()
+        public async Task DownloadHistoryForImage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-               .ImageDownloadHistory().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+               .ImageDownloadHistory().WithId("882449540").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/downloadhistory");
         }

--- a/UnitTests/Images/ImagesSimilarTests.cs
+++ b/UnitTests/Images/ImagesSimilarTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,49 +9,49 @@ namespace UnitTests.Images
     public class ImagesSimilarTests
     {
         [Fact]
-        public void ImagesSimilarBasic()
+        public async Task ImagesSimilarBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .ImagesSimilar().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .ImagesSimilar().WithId("882449540").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/similar");
         }
 
         [Fact]
-        public void ImagesSimilarWithResponseFields()
+        public async Task ImagesSimilarWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .ImagesSimilar().WithId("882449540").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .ImagesSimilar().WithId("882449540").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=country%2Cid");
         }
 
         [Fact]
-        public void ImagesSimilarWithPage()
+        public async Task ImagesSimilarWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .ImagesSimilar().WithId("882449540").WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .ImagesSimilar().WithId("882449540").WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=3");
         }
 
         [Fact]
-        public void ImagesSimilarWithPageSize()
+        public async Task ImagesSimilarWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .ImagesSimilar().WithId("882449540").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .ImagesSimilar().WithId("882449540").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");

--- a/UnitTests/Images/ImagesTests.cs
+++ b/UnitTests/Images/ImagesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,32 +9,32 @@ namespace UnitTests.Images
     public class ImagesTests
     {
         [Fact]
-        public void MultipleImagesBasic()
+        public async Task MultipleImagesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<string>() { "882449540", "629219532" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Images().WithIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Images().WithIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=882449540%2C629219532");
         }
 
         [Fact]
-        public void SingleImageBasic()
+        public async Task SingleImageBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Images().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Images().WithId("882449540").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540");
         }
 
         [Fact]
-        public void MultileImagesWithResponseFields()
+        public async Task MultipleImagesWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -41,8 +42,8 @@ namespace UnitTests.Images
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Images().WithIds(ids).WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Images().WithIds(ids).WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=882449540%2C629219532");
@@ -50,14 +51,14 @@ namespace UnitTests.Images
         }
 
         [Fact]
-        public void SingleImageWithResponseFields()
+        public async Task SingleImageWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Images().WithId("882449540").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Images().WithId("882449540").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("images/882449540");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=country%2Cid");

--- a/UnitTests/Orders/OrdersTests.cs
+++ b/UnitTests/Orders/OrdersTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace UnitTests.Orders
     public class OrdersTests
     {
         [Fact]
-        public void OrdersBasic()
+        public async Task OrdersBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Orders().WithId(1234).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Orders().WithId(1234).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("orders/1234");
         }

--- a/UnitTests/Products/ProductsTests.cs
+++ b/UnitTests/Products/ProductsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,25 +9,25 @@ namespace UnitTests.Products
     public class CountriesTests
     {
         [Fact]
-        public void ProductsBasic()
+        public async Task ProductsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Products()
-                .ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Products()
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("products");
         }
 
         [Fact]
-        public void ProductsWithResponseField()
+        public async Task ProductsWithResponseField()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "download_requirements" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Products()
-                .WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).Products()
+                .WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("products");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=download_requirements");

--- a/UnitTests/Purchases/PurchasedAssetsTests.cs
+++ b/UnitTests/Purchases/PurchasedAssetsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,59 +8,59 @@ namespace UnitTests.Purchases
     public class PurchasedAssetsTests
     {
         [Fact]
-        public void PurchasedAssetsBasic()
+        public async Task PurchasedAssetsBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedAssets().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedAssets().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-assets");
         }
 
         [Fact]
-        public void PurchasedAssetsWithEndDate()
+        public async Task PurchasedAssetsWithEndDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedAssets().WithEndDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedAssets().WithEndDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-assets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("end_date=2015-04-01");
         }
 
         [Fact]
-        public void PurchasedAssetsWithPage()
+        public async Task PurchasedAssetsWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedAssets().WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedAssets().WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-assets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=3");
         }
 
         [Fact]
-        public void PurchasedAssetsWithPageSize()
+        public async Task PurchasedAssetsWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedAssets().WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedAssets().WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-assets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");
         }
 
         [Fact]
-        public void PurchasedAssetsWithStartDate()
+        public async Task PurchasedAssetsWithStartDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedAssets().WithStartDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedAssets().WithStartDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-assets");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");

--- a/UnitTests/Purchases/PurchasedImagesTests.cs
+++ b/UnitTests/Purchases/PurchasedImagesTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,59 +8,59 @@ namespace UnitTests.Purchases
     public class PurchasedImagesTests
     {
         [Fact]
-        public void PurchasedImagesBasic()
+        public async Task PurchasedImagesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedImages().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedImages().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-images");
         }
 
         [Fact]
-        public void PurchasedImagesWithEndDate()
+        public async Task PurchasedImagesWithEndDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedImages().WithEndDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedImages().WithEndDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("end_date=2015-04-01");
         }
 
         [Fact]
-        public void PurchasedImagesWithPage()
+        public async Task PurchasedImagesWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedImages().WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedImages().WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=3");
         }
 
         [Fact]
-        public void PurchasedImagesWithPageSize()
+        public async Task PurchasedImagesWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedImages().WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedImages().WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");
         }
 
         [Fact]
-        public void PurchasedImagesWithStartDate()
+        public async Task PurchasedImagesWithStartDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .PurchasedImages().WithStartDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .PurchasedImages().WithStartDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("purchased-images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");

--- a/UnitTests/Search/SearchEventTests.cs
+++ b/UnitTests/Search/SearchEventTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,28 @@ namespace UnitTests.Search
     public class SearchEventTests
     {
         [Fact]
-        public void SearchForEventsWithPhrase()
+        public async Task SearchForEventsWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .SearchEvents()
+                .WithPhrase("cat")
+                .ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForEventsWithDateFrom()
+        public async Task SearchForEventsWithDateFrom()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithDateFrom("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .SearchEvents()
+                .WithPhrase("cat")
+                .WithDateFrom("2015-04-01")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,12 +39,15 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEventsWithDateTo()
+        public async Task SearchForEventsWithDateTo()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithDateTo("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .SearchEvents()
+                .WithPhrase("cat")
+                .WithDateTo("2015-04-01")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -46,12 +55,15 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEventsWithEditorialSegment()
+        public async Task SearchForEventsWithEditorialSegment()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithEditorialSegment(EditorialSegment.Archival).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .SearchEvents()
+                .WithPhrase("cat")
+                .WithEditorialSegment(EditorialSegment.Archival)
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -59,14 +71,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEventsWithReponseFields()
+        public async Task SearchForEventsWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "id", "keywords" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -74,12 +86,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEventsWithPage()
+        public async Task SearchForEventsWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -87,12 +99,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEventsWithPageSize()
+        public async Task SearchForEventsWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchEvents()
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/events");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/Search/SearchImagesCreativeTests.cs
+++ b/UnitTests/Search/SearchImagesCreativeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,23 @@ namespace UnitTests.Search
     public class SearchImagesCreativeTests
     {
         [Fact]
-        public void SearchForCreativeImagesWithPhrase()
+        public async Task SearchForCreativeImagesWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithAgeOfPeople()
+        public async Task SearchForCreativeImagesWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,14 +34,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithArtist()
+        public async Task SearchForCreativeImagesWithArtist()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var artists = new List<string>() {"roman makhmutov", "Linda Raymond"};
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithArtists(artists).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithArtists(artists).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -48,14 +49,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithCollectionCodes()
+        public async Task SearchForCreativeImagesWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -63,12 +64,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithCollectionFilterType()
+        public async Task SearchForCreativeImagesWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -76,12 +77,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithColor()
+        public async Task SearchForCreativeImagesWithColor()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithColor("#002244").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithColor("#002244").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -89,12 +90,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithComposition()
+        public async Task SearchForCreativeImagesWithComposition()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -102,12 +103,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithDownloadProduct()
+        public async Task SearchForCreativeImagesWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,12 +116,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithEmbedContentOnly()
+        public async Task SearchForCreativeImagesWithEmbedContentOnly()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -128,12 +129,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithEthnicity()
+        public async Task SearchForCreativeImagesWithEthnicity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -141,12 +142,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithExcludeNudity()
+        public async Task SearchForCreativeImagesWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -154,12 +155,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithWithExcludeEditorialUseOnly()
+        public async Task SearchForCreativeImagesWithWithExcludeEditorialUseOnly()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithExcludeEditorialUseOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithExcludeEditorialUseOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -167,14 +168,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithResponseFields()
+        public async Task SearchForCreativeImagesWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -182,12 +183,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithFileTypes()
+        public async Task SearchForCreativeImagesWithFileTypes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -195,12 +196,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithGraphicalStyle()
+        public async Task SearchForCreativeImagesWithGraphicalStyle()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Illustration).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Illustration).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -208,12 +209,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithGraphicalStyleFilter()
+        public async Task SearchForBlendedImagesWithGraphicalStyleFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -222,14 +223,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithKeywordId()
+        public async Task SearchForCreativeImagesWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() {64284, 67255};
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -237,12 +238,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithMinimumSize()
+        public async Task SearchForCreativeImagesWithMinimumSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithMinimumSize(MinimumSize.Small).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithMinimumSize(MinimumSize.Small).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -250,12 +251,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithNumberOfPeople()
+        public async Task SearchForCreativeImagesWithNumberOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -263,12 +264,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithOrientation()
+        public async Task SearchForCreativeImagesWithOrientation()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -276,12 +277,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithPage()
+        public async Task SearchForCreativeImagesWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -289,13 +290,13 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithPageSize()
+        public async Task SearchForCreativeImagesWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
                 .SearchImagesCreative()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -303,12 +304,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithPrestigeContent()
+        public async Task SearchForCreativeImagesWithPrestigeContent()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithPrestigeContentOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithPrestigeContentOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -316,12 +317,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithProductType()
+        public async Task SearchForCreativeImagesWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -329,12 +330,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithSortOrder()
+        public async Task SearchForCreativeImagesWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
-                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -342,17 +343,16 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeImagesWithFacets()
+        public async Task SearchForCreativeImagesWithFacets()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
                 .SearchImagesCreative()
                 .WithIncludeFacets()
                 .WithFacetMaxCount(200)
                 .WithFacetFields(new List<string>(){ "artists", "locations" })
-                .ExecuteAsync()
-                .Result;
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("include_facets=True");

--- a/UnitTests/Search/SearchImagesEditorialTests.cs
+++ b/UnitTests/Search/SearchImagesEditorialTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,23 @@ namespace UnitTests.Search
     public class SearchImagesEditorialTests
     {
         [Fact]
-        public void SearchForEditorialImagesWithPhrase()
+        public async Task SearchForEditorialImagesWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithAgeOfPeople()
+        public async Task SearchForEditorialImagesWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,14 +34,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithArtist()
+        public async Task SearchForEditorialImagesWithArtist()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var artists = new List<string>() { "roman makhmutov", "Linda Raymond" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithArtists(artists).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithArtists(artists).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -48,14 +49,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithCollectionCodes()
+        public async Task SearchForEditorialImagesWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -63,12 +64,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithCollectionFilterType()
+        public async Task SearchForEditorialImagesWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -76,12 +77,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithComposition()
+        public async Task SearchForEditorialImagesWithComposition()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -89,12 +90,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithDownloadProduct()
+        public async Task SearchForEditorialImagesWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -102,12 +103,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEditorialSegment()
+        public async Task SearchForEditorialImagesWithEditorialSegment()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEditorialSegment(EditorialSegment.Archival | EditorialSegment.Publicity).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEditorialSegment(EditorialSegment.Archival | EditorialSegment.Publicity).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,12 +116,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEmbedContentOnly()
+        public async Task SearchForEditorialImagesWithEmbedContentOnly()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -128,12 +129,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEndDate()
+        public async Task SearchForEditorialImagesWithEndDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEndDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEndDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -141,14 +142,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEntityUris()
+        public async Task SearchForEditorialImagesWithEntityUris()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var uris = new List<string>() { "example_uri_1", "example_uri_2" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEntityUris(uris).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEntityUris(uris).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -156,12 +157,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEthnicity()
+        public async Task SearchForEditorialImagesWithEthnicity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -169,14 +170,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithEventIds()
+        public async Task SearchForEditorialImagesWithEventIds()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 518451, 518452 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -184,12 +185,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithExcludeNudity()
+        public async Task SearchForEditorialImagesWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -197,14 +198,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithResponseFields()
+        public async Task SearchForEditorialImagesWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -212,12 +213,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithFileTypes()
+        public async Task SearchForEditorialImagesWithFileTypes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -225,12 +226,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithGraphicalStyle()
+        public async Task SearchForEditorialImagesWithGraphicalStyle()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt).WithGraphicalStyle(GraphicalStyles.Illustration).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt).WithGraphicalStyle(GraphicalStyles.Illustration).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -238,12 +239,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithGraphicalStyleFilter()
+        public async Task SearchForBlendedImagesWithGraphicalStyleFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -252,14 +253,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithKeywordId()
+        public async Task SearchForEditorialImagesWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 64284, 67255 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -267,12 +268,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithMinimumQualtiy()
+        public async Task SearchForEditorialImagesWithMinimumQualtiy()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithMinimumQuality(MinimumQuality.One).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithMinimumQuality(MinimumQuality.One).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -280,12 +281,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithMinimumSize()
+        public async Task SearchForEditorialImagesWithMinimumSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithMinimumSize(MinimumSize.Small).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithMinimumSize(MinimumSize.Small).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -293,12 +294,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithNumberOfPeople()
+        public async Task SearchForEditorialImagesWithNumberOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -306,12 +307,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithOrientation()
+        public async Task SearchForEditorialImagesWithOrientation()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -319,12 +320,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithPage()
+        public async Task SearchForEditorialImagesWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -332,12 +333,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithPageSize()
+        public async Task SearchForEditorialImagesWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -345,26 +346,25 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithProductType()
+        public async Task SearchForEditorialImagesWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_types=easyaccess");
         }
 
-
         [Fact]
-        public void SearchForEditorialImagesWithSortOrder()
+        public async Task SearchForEditorialImagesWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -372,14 +372,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithSpecificPeople()
+        public async Task SearchForEditorialImagesWithSpecificPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var people = new List<string>() { "Reggie Jackson" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -387,12 +387,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialImagesWithStartDate()
+        public async Task SearchForEditorialImagesWithStartDate()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
-                .WithPhrase("cat").WithStartDate("2015-04-01").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithStartDate("2015-04-01").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/Search/SearchImagesTests.cs
+++ b/UnitTests/Search/SearchImagesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,24 +10,26 @@ namespace UnitTests.Search
     public class SearchImagesTests
     {
         [Fact]
-        public void SearchForBlendedImagesWithPhrase()
+        public async Task SearchForBlendedImagesWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response =  ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await  ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .SearchImages()
+                .WithPhrase("cat")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithAgeOfPeople()
+        public async Task SearchForBlendedImagesWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -34,14 +37,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithArtist()
+        public async Task SearchForBlendedImagesWithArtist()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var artists = new List<string>() { "roman makhmutov", "Linda Raymond" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithArtists(artists).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithArtists(artists).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -49,26 +52,26 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithCollectionCodes()
+        public async Task SearchForBlendedImagesWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("collection_codes=WRI%2CARF");
         }
 
-        [Fact] public void SearchForBlendedImagesWithCollectionFilterType()
+        [Fact] public async Task SearchForBlendedImagesWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -76,12 +79,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithCollectionColor()
+        public async Task SearchForBlendedImagesWithCollectionColor()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithColor("#002244").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithColor("#002244").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -89,12 +92,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithComposition()
+        public async Task SearchForBlendedImagesWithComposition()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithComposition(Composition.Headshot | Composition.Abstract).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -102,12 +105,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithDownloadProduct()
+        public async Task SearchForBlendedImagesWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,12 +118,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEmbedContentOnly()
+        public async Task SearchForBlendedImagesWithEmbedContentOnly()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEmbedContentOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -128,12 +131,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEthnicity()
+        public async Task SearchForBlendedImagesWithEthnicity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEthnicity(Ethnicity.Black | Ethnicity.Japanese).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -141,14 +144,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEventIdsSingleId()
+        public async Task SearchForBlendedImagesWithEventIdsSingleId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 518451 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -156,14 +159,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEventIdsList()
+        public async Task SearchForBlendedImagesWithEventIdsList()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 518451, 518452 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -171,14 +174,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEventIdsListChainedWithDuplicates()
+        public async Task SearchForBlendedImagesWithEventIdsListChainedWithDuplicates()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 518451, 518452 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEventIds(ids).WithEventIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEventIds(ids).WithEventIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -186,7 +189,7 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEventIdsListChained()
+        public async Task SearchForBlendedImagesWithEventIdsListChained()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -194,8 +197,8 @@ namespace UnitTests.Search
 
             var ids2 = new List<int>() { 518453, 518454 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEventIds(ids).WithEventIds(ids2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEventIds(ids).WithEventIds(ids2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -203,14 +206,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithEventIdsArray()
+        public async Task SearchForBlendedImagesWithEventIdsArray()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var ids = new int[] { 518451, 518452 };
+            var ids = new[] { 518451, 518452 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithEventIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -218,12 +221,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithExcludeNudity()
+        public async Task SearchForBlendedImagesWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -231,14 +234,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithResponseFields()
+        public async Task SearchForBlendedImagesWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id", "uri_oembed" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -246,12 +249,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithFileTypes()
+        public async Task SearchForBlendedImagesWithFileTypes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithFileType(FileType.Eps | FileType.Jpg).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -259,12 +262,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithGraphicalStyle()
+        public async Task SearchForBlendedImagesWithGraphicalStyle()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Illustration).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Illustration).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -272,12 +275,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithGraphicalStyleFilter()
+        public async Task SearchForBlendedImagesWithGraphicalStyleFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithGraphicalStyle(GraphicalStyles.FineArt | GraphicalStyles.Vector).WithGraphicalStyleFilterType(GraphicalStyleFilter.Include).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -286,14 +289,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithKeywordId()
+        public async Task SearchForBlendedImagesWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 64284, 67255 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -301,12 +304,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithMinimumSize()
+        public async Task SearchForBlendedImagesWithMinimumSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithMinimumSize(MinimumSize.Xlarge).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithMinimumSize(MinimumSize.Xlarge).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -314,12 +317,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithNumberOfPeople()
+        public async Task SearchForBlendedImagesWithNumberOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithNumberOfPeople(NumberOfPeople.One | NumberOfPeople.Group).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -327,12 +330,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithOrientation()
+        public async Task SearchForBlendedImagesWithOrientation()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithOrientation(Orientation.Horizontal | Orientation.Square).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -340,12 +343,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithPage()
+        public async Task SearchForBlendedImagesWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -353,13 +356,13 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithPageSize()
+        public async Task SearchForBlendedImagesWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
                 .SearchImages()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -367,12 +370,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithPrestigeContent()
+        public async Task SearchForBlendedImagesWithPrestigeContent()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithPrestigeContentOnly().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithPrestigeContentOnly().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -380,12 +383,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithProductType()
+        public async Task SearchForBlendedImagesWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -393,12 +396,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithSortOrder()
+        public async Task SearchForBlendedImagesWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithSortOrder(SortOrder.Newest).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithSortOrder(SortOrder.Newest).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -406,14 +409,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedImagesWithSpecificPeople()
+        public async Task SearchForBlendedImagesWithSpecificPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var people = new List<string>() { "Reggie Jackson" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
-                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImages()
+                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/Search/SearchVideosCreativeTests.cs
+++ b/UnitTests/Search/SearchVideosCreativeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,23 @@ namespace UnitTests.Search
     public class SearchVideosCreativeTests
     {
         [Fact]
-        public void SearchForCreativeVideosWithPhrase()
+        public async Task SearchForCreativeVideosWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithAgeOfPeople()
+        public async Task SearchForCreativeVideosWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,14 +34,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithCollectionCodes()
+        public async Task SearchForCreativeVideosWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -48,12 +49,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithCollectionFilterType()
+        public async Task SearchForCreativeVideosWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -61,12 +62,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithDownloadProduct()
+        public async Task SearchForCreativeVideosWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos/creative");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -74,12 +75,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithExcludeNudity()
+        public async Task SearchForCreativeVideosWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -87,14 +88,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithResponseFields()
+        public async Task SearchForCreativeVideosWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -102,12 +103,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithFormatFilter()
+        public async Task SearchForCreativeVideosWithFormatFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,12 +116,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithFrameRates()
+        public async Task SearchForCreativeVideosWithFrameRates()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -128,14 +129,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithKeywordId()
+        public async Task SearchForCreativeVideosWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 64284, 67255 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -143,12 +144,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithLicenseModel()
+        public async Task SearchForCreativeVideosWithLicenseModel()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsReady | LicenseModel.RoyaltyFree).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsReady | LicenseModel.RoyaltyFree).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -156,12 +157,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithPage()
+        public async Task SearchForCreativeVideosWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -169,12 +170,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithPageSize()
+        public async Task SearchForCreativeVideosWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -182,12 +183,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithProductType()
+        public async Task SearchForCreativeVideosWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -195,12 +196,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithSortOrder()
+        public async Task SearchForCreativeVideosWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -208,12 +209,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithReleaseStatus()
+        public async Task SearchForCreativeVideosWithReleaseStatus()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.ReleaseNotImportant).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.ReleaseNotImportant).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -221,12 +222,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithMinimumClipLength()
+        public async Task SearchForCreativeVideosWithMinimumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -234,12 +235,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithMaximumClipLength()
+        public async Task SearchForCreativeVideosWithMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -247,12 +248,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForCreativeVideosWithMinimumAndMaximumClipLength()
+        public async Task SearchForCreativeVideosWithMinimumAndMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosCreative()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/Search/SearchVideosEditorialTests.cs
+++ b/UnitTests/Search/SearchVideosEditorialTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,23 @@ namespace UnitTests.Search
     public class SearchVideosEditorialTests
     {
         [Fact]
-        public void SearchForEditorialVideosWithPhrase()
+        public async Task SearchForEditorialVideosWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithAgeOfPeople()
+        public async Task SearchForEditorialVideosWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,14 +34,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithCollectionCodes()
+        public async Task SearchForEditorialVideosWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -48,12 +49,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithCollectionFilterType()
+        public async Task SearchForEditorialVideosWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -61,12 +62,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithDownloadProduct()
+        public async Task SearchForEditorialVideosWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos/editorial");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -74,12 +75,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithEditorialVideoType()
+        public async Task SearchForEditorialVideosWithEditorialVideoType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithEditorialVideoType(EditorialVideo.Raw | EditorialVideo.Produced).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithEditorialVideoType(EditorialVideo.Raw | EditorialVideo.Produced).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -87,14 +88,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithEntityUri()
+        public async Task SearchForEditorialVideosWithEntityUri()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var uris = new List<string>() { "example_uri_1", "example_uri_2" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithEntityUris(uris).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithEntityUris(uris).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -102,12 +103,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithExcludeNudity()
+        public async Task SearchForEditorialVideosWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,14 +116,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithResponseFields()
+        public async Task SearchForEditorialVideosWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -130,12 +131,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithFormatFilter()
+        public async Task SearchForEditorialVideosWithFormatFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -143,12 +144,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithFrameRates()
+        public async Task SearchForEditorialVideosWithFrameRates()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -156,28 +157,27 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithKeywordId()
+        public async Task SearchForEditorialVideosWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 64284, 67255 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("keyword_ids=64284%2C67255");
         }
 
-
         [Fact]
-        public void SearchForEditorialVideosWithPage()
+        public async Task SearchForEditorialVideosWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -185,12 +185,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithPageSize()
+        public async Task SearchForEditorialVideosWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -198,26 +198,25 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithProductType()
+        public async Task SearchForEditorialVideosWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("product_types=editorialsubscription%2Ceasyaccess");
         }
 
-
         [Fact]
-        public void SearchForEditorialVideosWithSortOrder()
+        public async Task SearchForEditorialVideosWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -225,14 +224,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithSpecificPeople()
+        public async Task SearchForEditorialVideosWithSpecificPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var people = new List<string>() { "Reggie Jackson" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -240,12 +239,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithReleaseStatus()
+        public async Task SearchForEditorialVideosWithReleaseStatus()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.FullyReleased).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.FullyReleased).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -253,12 +252,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithMinimumClipLength()
+        public async Task SearchForEditorialVideosWithMinimumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -266,12 +265,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithMaximumClipLength()
+        public async Task SearchForEditorialVideosWithMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -279,12 +278,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForEditorialVideosWithMinimumAndMaximumClipLength()
+        public async Task SearchForEditorialVideosWithMinimumAndMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideosEditorial()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/Search/SearchVideosTests.cs
+++ b/UnitTests/Search/SearchVideosTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using GettyImages.Api.Entity;
@@ -9,23 +10,23 @@ namespace UnitTests.Search
     public class SearchVideosTests
     {
         [Fact]
-        public void SearchForBlendedVideosWithPhrase()
+        public async Task SearchForBlendedVideosWithPhrase()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response =  ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").ExecuteAsync().Result;
+            await  ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").ExecuteAsync();
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithAgeOfPeople()
+        public async Task SearchForBlendedVideosWithAgeOfPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithAgeOfPeople(AgeOfPeople.Months6To11 | AgeOfPeople.Adult).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -33,14 +34,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithCollectionCodes()
+        public async Task SearchForBlendedVideosWithCollectionCodes()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var codes = new List<string>() { "WRI", "ARF" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithCollectionCodes(codes).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -48,12 +49,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithCollectionFilterType()
+        public async Task SearchForBlendedVideosWithCollectionFilterType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithCollectionFilterType(CollectionFilter.Exclude).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -61,12 +62,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithDownloadProduct()
+        public async Task SearchForBlendedVideosWithDownloadProduct()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithDownloadProduct(ProductType.Easyaccess).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -74,12 +75,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithEditorialVideoType()
+        public async Task SearchForBlendedVideosWithEditorialVideoType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithEditorialVideoType(EditorialVideo.Raw | EditorialVideo.Produced).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithEditorialVideoType(EditorialVideo.Raw | EditorialVideo.Produced).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -87,12 +88,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithExcludeNudity()
+        public async Task SearchForBlendedVideosWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithExcludeNudity().ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -100,14 +101,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithResponseFields()
+        public async Task SearchForBlendedVideosWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "asset_family", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -115,12 +116,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithFormatFilter()
+        public async Task SearchForBlendedVideosWithFormatFilter()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithAvailableFormat("HD").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -128,12 +129,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithFrameRates()
+        public async Task SearchForBlendedVideosWithFrameRates()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithFrameRate(FrameRate.FrameRate24 | FrameRate.FrameRate29).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -141,14 +142,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithKeywordId()
+        public async Task SearchForBlendedVideosWithKeywordId()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<int>() { 64284, 67255 };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithKeywordIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -156,12 +157,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithLicenseModel()
+        public async Task SearchForBlendedVideosWithLicenseModel()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsReady | LicenseModel.RoyaltyFree).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithLicenseModel(LicenseModel.RightsReady | LicenseModel.RoyaltyFree).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -169,12 +170,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithPage()
+        public async Task SearchForBlendedVideosWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithPage(2).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithPage(2).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -182,13 +183,13 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithPageSize()
+        public async Task SearchForBlendedVideosWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
                 .SearchVideos()
-                .WithPhrase("cat").WithPageSize(50).ExecuteAsync().Result;
+                .WithPhrase("cat").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -196,12 +197,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithProductType()
+        public async Task SearchForBlendedVideosWithProductType()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithProductType(ProductType.Easyaccess | ProductType.Editorialsubscription).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -209,12 +210,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithSortOrder()
+        public async Task SearchForBlendedVideosWithSortOrder()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithSortOrder(SortOrder.BestMatch).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -222,14 +223,14 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForBlendedVideosWithSpecificPeople()
+        public async Task SearchForBlendedVideosWithSpecificPeople()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var people = new List<string>() { "Reggie Jackson" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithSpecificPeople(people).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -237,12 +238,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForVideosWithReleaseStatus()
+        public async Task SearchForVideosWithReleaseStatus()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.FullyReleased).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+                .WithPhrase("cat").WithReleaseStatus(ReleaseStatus.FullyReleased).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -250,12 +251,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForVideosWithMinimumClipLength()
+        public async Task SearchForVideosWithMinimumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -263,12 +264,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForVideosWithMaximumClipLength()
+        public async Task SearchForVideosWithMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
@@ -276,12 +277,12 @@ namespace UnitTests.Search
         }
 
         [Fact]
-        public void SearchForVideosWithMinimumAndMaximumClipLength()
+        public async Task SearchForVideosWithMinimumAndMaximumClipLength()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
-               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchVideos()
+               .WithPhrase("cat").WithMinimumVideoClipLength(20).WithMaximumVideoClipLength(200).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");

--- a/UnitTests/TestHandler.cs
+++ b/UnitTests/TestHandler.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 
 namespace UnitTests
 {
-
     public class TestHandler : DelegatingHandler
     {
         private readonly HttpResponseMessage _httpResponseMessage;

--- a/UnitTests/Usage/UsageBatchesTests.cs
+++ b/UnitTests/Usage/UsageBatchesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,7 +9,7 @@ namespace UnitTests.Usage
     public class UsageBatchesTests
     {
         [Fact]
-        public void UsageBatchesBasic()
+        public async Task UsageBatchesBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -21,8 +22,8 @@ namespace UnitTests.Usage
                 }
                 ]
             }";
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).UsageBatches()
-                .WithId("464423888").WithRequest(request).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).UsageBatches()
+                .WithId("464423888").WithRequest(request).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("usage-batches/464423888");
             testHandler.Request.Method.Should().Be(HttpMethod.Put);

--- a/UnitTests/Videos/VideosDownloadHistoryTests.cs
+++ b/UnitTests/Videos/VideosDownloadHistoryTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
 
@@ -7,24 +8,29 @@ namespace UnitTests.Videos
     public class VideosDownloadHistoryTests
     {
         [Fact]
-        public void ImageDownloadHistoryWithCompanyDownloads()
+        public async Task ImageDownloadHistoryWithCompanyDownloads()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-               .VideoDownloadHistory().WithId("882449540").WithCompanyDownloads().ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+               .VideoDownloadHistory()
+               .WithId("882449540")
+               .WithCompanyDownloads()
+               .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/downloadhistory");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("company_downloads=True");
         }
 
         [Fact]
-        public void DownloadHistoryForImage()
+        public async Task DownloadHistoryForImage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-               .VideoDownloadHistory().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .VideoDownloadHistory()
+                .WithId("882449540")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/downloadhistory");
         }

--- a/UnitTests/Videos/VideosSimilarTests.cs
+++ b/UnitTests/Videos/VideosSimilarTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,49 +9,51 @@ namespace UnitTests.Videos
     public class VideosSimilarTests
     {
         [Fact]
-        public void VideosSimilarBasic()
+        public async Task VideosSimilarBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .VideosSimilar().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .VideosSimilar()
+                .WithId("882449540")
+                .ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/similar");
         }
 
         [Fact]
-        public void VideosSimilarWithResponseFields()
+        public async Task VideosSimilarWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .VideosSimilar().WithId("882449540").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .VideosSimilar().WithId("882449540").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=country%2Cid");
         }
 
         [Fact]
-        public void VideosSimilarWithPage()
+        public async Task VideosSimilarWithPage()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .VideosSimilar().WithId("882449540").WithPage(3).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .VideosSimilar().WithId("882449540").WithPage(3).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page=3");
         }
 
         [Fact]
-        public void VideosSimilarWithPageSize()
+        public async Task VideosSimilarWithPageSize()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .VideosSimilar().WithId("882449540").WithPageSize(50).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .VideosSimilar().WithId("882449540").WithPageSize(50).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540/similar");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("page_size=50");

--- a/UnitTests/Videos/VideosTests.cs
+++ b/UnitTests/Videos/VideosTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GettyImages.Api;
 using Xunit;
@@ -8,32 +9,32 @@ namespace UnitTests.Videos
     public class VideosTests
     {
         [Fact]
-        public void MultipleVideosBasic()
+        public async Task MultipleVideosBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var ids = new List<string>() { "882449540", "629219532" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Videos().WithIds(ids).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Videos().WithIds(ids).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=882449540%2C629219532");
         }
 
         [Fact]
-        public void SingleVideoBasic()
+        public async Task SingleVideoBasic()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Videos().WithId("882449540").ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Videos().WithId("882449540").ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540");
         }
 
         [Fact]
-        public void MultileVideosWithResponseFields()
+        public async Task MultipleVideosWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
@@ -41,8 +42,8 @@ namespace UnitTests.Videos
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Videos().WithIds(ids).WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Videos().WithIds(ids).WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("ids=882449540%2C629219532");
@@ -50,14 +51,14 @@ namespace UnitTests.Videos
         }
 
         [Fact]
-        public void SingleVideoWithResponseFields()
+        public async Task SingleVideoWithResponseFields()
         {
             var testHandler = TestUtil.CreateTestHandler();
 
             var fields = new List<string>() { "country", "id" };
 
-            var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-                .Videos().WithId("882449540").WithResponseFields(fields).ExecuteAsync().Result;
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+                .Videos().WithId("882449540").WithResponseFields(fields).ExecuteAsync();
 
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("videos/882449540");
             testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("fields=country%2Cid");

--- a/UnitTests/WebHelper/WebHelperTests.cs
+++ b/UnitTests/WebHelper/WebHelperTests.cs
@@ -10,7 +10,7 @@ namespace UnitTests
     public class WebHelperTests
     {
         [Fact]
-        public void Check500CodeTest()
+        public async Task Check500CodeTest()
         {
             var httpResponse = new HttpResponseMessage();
             httpResponse.StatusCode = (HttpStatusCode) 500;
@@ -20,9 +20,9 @@ namespace UnitTests
             var response = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
                 .SearchImages().WithPhrase("cat");
 
-            Task<NullReferenceException> ex = Assert.ThrowsAsync<NullReferenceException>(async () => await response.ExecuteAsync());
+            var ex = await Assert.ThrowsAsync<NullReferenceException>(async () => await response.ExecuteAsync());
 
-            Assert.Equal("Object reference not set to an instance of an object.", ex.Result.Message);
+            Assert.Equal("Object reference not set to an instance of an object.", ex.Message);
 
             Assert.True(testHandler.NumberOfCallsSendAsync >= 2);
         }


### PR DESCRIPTION
xUnit supports `async` on test methods.  It would be best to have the tests exercise the SDK asynchronously as we want to encourage async calls as opposed to lots of `.Result` and `.Wait()` calls.