### PR TITLE
Fix NuGet warnings

### DIFF
--- a/GettyImages.Api/GettyImages.Api.csproj
+++ b/GettyImages.Api/GettyImages.Api.csproj
@@ -11,7 +11,7 @@
     <Description>Allows easy integration with the Getty Images API.</Description>
     <Copyright>Copyright © 2014 - 2018 Getty Images</Copyright>
     <PackageTags>Getty Images Videos API SDK GettyImages Photo Photos Search Creative Editorial Artist Embed</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/gettyimages/gettyimages-api_dotnet</PackageProjectUrl>
     <PackageIcon>package-icon.jpg</PackageIcon>
     <RepositoryUrl>https://github.com/gettyimages/gettyimages-api_dotnet</RepositoryUrl>


### PR DESCRIPTION
There are compiler warnings about deprecated NuGet tags in `GettyImages.Api.csproj`.  This should fix those.