### PR TITLE
Add Polly, basic retry policy, extension methods for HttpClient

### DIFF
--- a/GettyImages.Api/GettyImages.Api.csproj
+++ b/GettyImages.Api/GettyImages.Api.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../LICENSE" Pack="true" PackagePath=""/>

--- a/GettyImages.Api/PollyHttpClientExtensions.cs
+++ b/GettyImages.Api/PollyHttpClientExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Extensions.Http;
+using Polly.Retry;
+
+namespace GettyImages.Api
+{
+    internal static class PollyHttpClientExtensions
+    {
+        private static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy;
+
+        static PollyHttpClientExtensions()
+        {
+            // TODO - Can Polly be used for all the UnauthorizedException manual retries in WebHelper?
+
+            RetryPolicy =
+                HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(responseMessage => (int) responseMessage.StatusCode == 429)
+                    .WaitAndRetryAsync(3, retryAttempt =>
+                        TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                    );
+        }
+
+        public static Task<HttpResponseMessage> GetAsyncWithRetryPolicy(this HttpClient httpClient, Uri uri)
+        {
+            return RetryPolicy.ExecuteAsync(() => httpClient.GetAsync(uri));
+        }
+        
+        public static Task<HttpResponseMessage> PostAsyncWithRetryPolicy(this HttpClient httpClient, 
+            string requestUri, HttpContent content)
+        {
+            return RetryPolicy.ExecuteAsync(() => httpClient.PostAsync(requestUri, content));
+        }
+        
+        public static Task<HttpResponseMessage> PostAsyncWithRetryPolicy(this HttpClient httpClient, 
+            Uri requestUri, HttpContent content)
+        {
+            return RetryPolicy.ExecuteAsync(() => httpClient.PostAsync(requestUri, content));
+        }
+        
+        public static Task<HttpResponseMessage> PutAsyncWithRetryPolicy(this HttpClient httpClient, 
+            Uri requestUri, HttpContent content)
+        {
+            return RetryPolicy.ExecuteAsync(() => httpClient.PutAsync(requestUri, content));
+        }
+        
+        public static Task<HttpResponseMessage> DeleteAsyncWithRetryPolicy(this HttpClient httpClient, 
+            Uri requestUri)
+        {
+            return RetryPolicy.ExecuteAsync(() => httpClient.DeleteAsync(requestUri));
+        }
+    }
+}

--- a/GettyImages.Api/PollyHttpClientExtensions.cs
+++ b/GettyImages.Api/PollyHttpClientExtensions.cs
@@ -13,8 +13,6 @@ namespace GettyImages.Api
 
         static PollyHttpClientExtensions()
         {
-            // TODO - Can Polly be used for all the UnauthorizedException manual retries in WebHelper?
-
             RetryPolicy =
                 HttpPolicyExtensions
                     .HandleTransientHttpError()

--- a/GettyImages.Api/PollyHttpClientExtensions.cs
+++ b/GettyImages.Api/PollyHttpClientExtensions.cs
@@ -18,7 +18,7 @@ namespace GettyImages.Api
                     .HandleTransientHttpError()
                     .OrResult(responseMessage => (int) responseMessage.StatusCode == 429)
                     .WaitAndRetryAsync(3, retryAttempt =>
-                        TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                        TimeSpan.FromSeconds(retryAttempt)
                     );
         }
 

--- a/GettyImages.Api/PollyHttpClientExtensions.cs
+++ b/GettyImages.Api/PollyHttpClientExtensions.cs
@@ -18,7 +18,7 @@ namespace GettyImages.Api
                     .HandleTransientHttpError()
                     .OrResult(responseMessage => (int) responseMessage.StatusCode == 429)
                     .WaitAndRetryAsync(3, retryAttempt =>
-                        TimeSpan.FromSeconds(retryAttempt)
+                        TimeSpan.FromMilliseconds(retryAttempt * 100)
                     );
         }
 

--- a/GettyImages.Api/WebHelper.cs
+++ b/GettyImages.Api/WebHelper.cs
@@ -34,13 +34,7 @@ namespace GettyImages.Api
                         BuildQuery(queryParameters)
                 };
 
-                var httpResponse = await client.GetAsync(builder.Uri);
-
-                if ((int)httpResponse.StatusCode >= 500)
-                {
-                    Task.Delay(1000).Wait();
-                    httpResponse = await client.GetAsync(builder.Uri);
-                }
+                var httpResponse = await client.GetAsyncWithRetryPolicy(builder.Uri);
 
                 try
                 {
@@ -51,7 +45,7 @@ namespace GettyImages.Api
                     _credentials.ResetAccessToken();
                     using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
-                        httpResponse = await retryClient.GetAsync(builder.Uri);
+                        httpResponse = await retryClient.GetAsyncWithRetryPolicy(builder.Uri);
                         return await HandleResponseAsync(httpResponse);
                     }
                 }
@@ -69,13 +63,7 @@ namespace GettyImages.Api
                 var uri = _baseAddress + path;
                 var formContent = new FormUrlEncodedContent(formParameters);
 
-                var httpResponse = await client.PostAsync(uri, formContent);
-
-                if ((int)httpResponse.StatusCode >= 500)
-                {
-                    Task.Delay(1000).Wait();
-                    httpResponse = await client.PostAsync(uri, formContent);
-                }
+                var httpResponse = await client.PostAsyncWithRetryPolicy(uri, formContent);
 
                 try
                 {
@@ -88,7 +76,7 @@ namespace GettyImages.Api
                         _credentials.ResetAccessToken();
                         using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                         {
-                            httpResponse = await retryClient.PostAsync(uri, formContent);
+                            httpResponse = await retryClient.PostAsyncWithRetryPolicy(uri, formContent);
                             return await HandleResponseAsync(httpResponse);
                         }
                     }
@@ -105,13 +93,7 @@ namespace GettyImages.Api
                 var uri = _baseAddress + path;
                 var requestUri = new UriBuilder(uri) { Query = BuildQuery(queryParameters) }.Uri;
 
-                var httpResponse = await client.PostAsync(requestUri, bodyParameter);
-
-                if ((int)httpResponse.StatusCode >= 500)
-                {
-                    Task.Delay(1000).Wait();
-                    httpResponse = await client.PostAsync(requestUri, bodyParameter);
-                }
+                var httpResponse = await client.PostAsyncWithRetryPolicy(requestUri, bodyParameter);
 
                 try
                 {
@@ -122,7 +104,7 @@ namespace GettyImages.Api
                     _credentials.ResetAccessToken();
                     using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
-                        httpResponse = await retryClient.PostAsync(requestUri, bodyParameter);
+                        httpResponse = await retryClient.PostAsyncWithRetryPolicy(requestUri, bodyParameter);
                         return await HandleResponseAsync(httpResponse);
                     }
                 }
@@ -137,13 +119,7 @@ namespace GettyImages.Api
                 var uri = _baseAddress + path;
                 var requestUri = new UriBuilder(uri) { Query = BuildQuery(queryParameters) }.Uri;
 
-                var httpResponse = await client.PutAsync(requestUri, bodyParameter);
-
-                if ((int)httpResponse.StatusCode >= 500)
-                {
-                    Task.Delay(1000).Wait();
-                    httpResponse = await client.PutAsync(requestUri, bodyParameter);
-                }
+                var httpResponse = await client.PutAsyncWithRetryPolicy(requestUri, bodyParameter);
 
                 try
                 {
@@ -154,7 +130,7 @@ namespace GettyImages.Api
                     _credentials.ResetAccessToken();
                     using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
-                        httpResponse = await retryClient.PutAsync(requestUri, bodyParameter);
+                        httpResponse = await retryClient.PutAsyncWithRetryPolicy(requestUri, bodyParameter);
                         return await HandleResponseAsync(httpResponse);
                     }
                 }
@@ -173,13 +149,7 @@ namespace GettyImages.Api
                         BuildQuery(queryParameters)
                 };
 
-                var httpResponse = await client.DeleteAsync(builder.Uri);
-
-                if ((int)httpResponse.StatusCode >= 500)
-                {
-                    Task.Delay(1000).Wait();
-                    httpResponse = await client.DeleteAsync(builder.Uri);
-                }
+                var httpResponse = await client.DeleteAsyncWithRetryPolicy(builder.Uri);
 
                 try
                 {
@@ -190,7 +160,7 @@ namespace GettyImages.Api
                     _credentials.ResetAccessToken();
                     using (var retryClient = new HttpClient(await GetHandlersAsync(headerParameters)))
                     {
-                        httpResponse = await retryClient.DeleteAsync(builder.Uri);
+                        httpResponse = await retryClient.DeleteAsyncWithRetryPolicy(builder.Uri);
                         return await HandleResponseAsync(httpResponse);
                     }
                 }


### PR DESCRIPTION
Add Polly and general retry policy for transient errors (e.g. 500, 408, 429).