### PR TITLE
Add support for excluding a set of keywords from search results

### DIFF
--- a/GettyImages.Api/ApiRequest.cs
+++ b/GettyImages.Api/ApiRequest.cs
@@ -398,9 +398,23 @@ namespace GettyImages.Api
             }
             else
             {
-                var assets = QueryParameters[Constants.KeywordIdsKey] as IEnumerable<int>;
-                assets = assets.Union(values).Distinct();
-                QueryParameters[Constants.KeywordIdsKey] = assets.ToList();
+                var keywords = QueryParameters[Constants.KeywordIdsKey] as IEnumerable<int>;
+                keywords = keywords.Union(values).Distinct();
+                QueryParameters[Constants.KeywordIdsKey] = keywords.ToList();
+            }
+        }
+        
+        protected void AddExcludeKeywordIds(IEnumerable<int> values)
+        {
+            if (!QueryParameters.ContainsKey(Constants.ExcludeKeywordIdsKey))
+            {
+                QueryParameters.Add(Constants.ExcludeKeywordIdsKey, values);
+            }
+            else
+            {
+                var keywords = QueryParameters[Constants.ExcludeKeywordIdsKey] as IEnumerable<int>;
+                keywords = keywords.Union(values).Distinct();
+                QueryParameters[Constants.ExcludeKeywordIdsKey] = keywords.ToList();
             }
         }
 

--- a/GettyImages.Api/Constants.cs
+++ b/GettyImages.Api/Constants.cs
@@ -26,6 +26,7 @@ namespace GettyImages.Api
         public const string EntityUriKey = "entity_uris";
         public const string EthnicityKey = "ethnicity";
         public const string EventIdsKey = "event_ids";
+        public const string ExcludeKeywordIdsKey = "exclude_keyword_ids";
         public const string Excludenudity = "exclude_nudity";
         public const string ExcludeEditorialUseOnly = "exclude_editorial_use_only";
         public const string FacetFieldsKey = "facet_fields";

--- a/GettyImages.Api/Search/SearchImagesCreative.cs
+++ b/GettyImages.Api/Search/SearchImagesCreative.cs
@@ -88,6 +88,12 @@ namespace GettyImages.Api.Search
             return this;
         }
 
+        public SearchImagesCreative WithExcludeKeywordIds(IEnumerable<int> values)
+        {
+            AddExcludeKeywordIds(values);
+            return this;
+        }
+        
         public SearchImagesCreative WithExcludeNudity(bool value = true)
         {
             AddQueryParameter(Constants.Excludenudity, value);

--- a/GettyImages.Api/Search/SearchImagesEditorial.cs
+++ b/GettyImages.Api/Search/SearchImagesEditorial.cs
@@ -106,6 +106,12 @@ namespace GettyImages.Api.Search
             return this;
         }
 
+        public SearchImagesEditorial WithExcludeKeywordIds(IEnumerable<int> values)
+        {
+            AddExcludeKeywordIds(values);
+            return this;
+        }
+        
         public SearchImagesEditorial WithExcludeNudity(bool value = true)
         {
             AddQueryParameter(Constants.Excludenudity, value);

--- a/UnitTests/Search/SearchImagesCreativeTests.cs
+++ b/UnitTests/Search/SearchImagesCreativeTests.cs
@@ -142,6 +142,21 @@ namespace UnitTests.Search
         }
 
         [Fact]
+        public async Task SearchForCreativeImagesWithExcludeKeywordIds()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var ids = new List<int>() {64284, 67255};
+
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesCreative()
+                .WithPhrase("cat").WithExcludeKeywordIds(ids).ExecuteAsync();
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/creative");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("exclude_keyword_ids=64284%2C67255");
+        }
+        
+        [Fact]
         public async Task SearchForCreativeImagesWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();

--- a/UnitTests/Search/SearchImagesEditorialTests.cs
+++ b/UnitTests/Search/SearchImagesEditorialTests.cs
@@ -185,6 +185,21 @@ namespace UnitTests.Search
         }
 
         [Fact]
+        public async Task SearchForEditorialImagesWithExcludeKeywordIds()
+        {
+            var testHandler = TestUtil.CreateTestHandler();
+
+            var ids = new List<int>() { 64284, 67255 };
+
+            await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler).SearchImagesEditorial()
+                .WithPhrase("cat").WithExcludeKeywordIds(ids).ExecuteAsync();
+
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
+            testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("exclude_keyword_ids=64284%2C67255");
+        }
+        
+        [Fact]
         public async Task SearchForEditorialImagesWithExcludeNudity()
         {
             var testHandler = TestUtil.CreateTestHandler();


### PR DESCRIPTION
Allows a set of excluded keyword ids to be added to creative and editorial images searches.