### PR TITLE
Add Unknown value to orientation enum for images response

### DIFF
--- a/GettyImages.Api/Models/OrientationImagesResponse.cs
+++ b/GettyImages.Api/Models/OrientationImagesResponse.cs
@@ -10,6 +10,7 @@ namespace GettyImages.Api.Models
         PanoramicHorizontal = 2,
         PanoramicVertical = 4,
         Square = 8,
-        Vertical = 16
+        Vertical = 16,
+        Unknown = 32
     }
 }


### PR DESCRIPTION
SDK Request:
`var imageMetadata = await client.Images().WithId(173372132).ExecuteAsync();`

```
Json Response:

{
    "images": [
        {
            "...":"..."
            "orientation": "Unknown",
        }
    ],
    "images_not_found": []
}
```

Trying to parse the EnumValue `Unknown` throws an error as the enum doesn't contain this value

Added "Unknown" to the OrientationImagesResponse enum