### PR TITLE
Fix publish tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --configuration Release --no-build --no-restore --verbosity normal -f net6
+      run: dotnet test --configuration Release --no-build --no-restore --verbosity normal -f net6 ./UnitTests/UnitTests.csproj
     - uses: actions/upload-artifact@v4
       with:
         name: artifacts


### PR DESCRIPTION
To fix https://github.com/gettyimages/gettyimages-api_dotnet/actions/runs/8759756845/job/24045121055

I neglected to use the same `dotnet test` change in `publish.yml` as I [made in `build.yml`](https://github.com/gettyimages/gettyimages-api_dotnet/blob/4e0fd43b07bd2e0cc7dc27b6bbfae06dbba8db87/.github/workflows/build.yml#L20).