### PR TITLE
Refactor query parameter constants and update tests

### DIFF
--- a/GettyImages.Api/Constants.cs
+++ b/GettyImages.Api/Constants.cs
@@ -26,7 +26,6 @@ internal static class Constants
     public const string EditorialSegmentKey = "editorial_segment";
     public const string EditorialVideoKey = "editorial_video_types";
     public const string EmbedContentOnlyKey = "embed_content_only";
-    public const string EndDateKey = "end_date";
     public const string EntityUriKey = "entity_uris";
     public const string EthnicityKey = "ethnicity";
     public const string EventIdsKey = "event_ids";
@@ -68,7 +67,6 @@ internal static class Constants
     public const string SortOrderKey = "sort_order";
     public const string LocationKey = "specific_locations";
     public const string SpecificPeopleKey = "specific_people";
-    public const string StartDateKey = "start_date";
     public const string ReleaseStatus = "release_status";
     public const string UseTeamCredits = "use_team_credits";
     public const string UseTimeKey = "use_time";

--- a/GettyImages.Api/Download/Downloads.cs
+++ b/GettyImages.Api/Download/Downloads.cs
@@ -32,7 +32,7 @@ public class Downloads : ApiRequest<GetDownloadsResponse>
 
     public Downloads WithEndDate(string value)
     {
-        AddQueryParameter(Constants.EndDateKey, value);
+        AddQueryParameter(Constants.DateToKey, value);
         return this;
     }
 
@@ -56,7 +56,7 @@ public class Downloads : ApiRequest<GetDownloadsResponse>
 
     public Downloads WithStartDate(string value)
     {
-        AddQueryParameter(Constants.StartDateKey, value);
+        AddQueryParameter(Constants.DateFromKey, value);
         return this;
     }
 

--- a/GettyImages.Api/Search/SearchImagesEditorial.cs
+++ b/GettyImages.Api/Search/SearchImagesEditorial.cs
@@ -93,7 +93,7 @@ public class SearchImagesEditorial : ApiRequest<SearchEditorialImagesResponse>
 
     public SearchImagesEditorial WithEndDate(string value)
     {
-        AddQueryParameter(Constants.EndDateKey, value);
+        AddQueryParameter(Constants.DateToKey, value);
         return this;
     }
 
@@ -202,7 +202,7 @@ public class SearchImagesEditorial : ApiRequest<SearchEditorialImagesResponse>
 
     public SearchImagesEditorial WithStartDate(string value)
     {
-        AddQueryParameter(Constants.StartDateKey, value);
+        AddQueryParameter(Constants.DateFromKey, value);
         return this;
     }
 
@@ -223,7 +223,7 @@ public class SearchImagesEditorial : ApiRequest<SearchEditorialImagesResponse>
         AddQueryParameter(Constants.FacetMaxCountKey, value);
         return this;
     }
-    
+
     public SearchImagesEditorial IncludeKeywords()
     {
         AddResponseField("keywords");

--- a/UnitTests/Downloads/DownloadsTests.cs
+++ b/UnitTests/Downloads/DownloadsTests.cs
@@ -44,7 +44,7 @@ public class DownloadsTests
             .ExecuteAsync();
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
-        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("end_date=2015-04-01");
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("date_to=2015-04-01");
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class DownloadsTests
             .ExecuteAsync();
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
-        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("date_from=2015-04-01");
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class DownloadsTests
             .ExecuteAsync();
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("downloads");
-        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("date_from=2015-04-01");
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("use_time=True");
     }
 }

--- a/UnitTests/Search/SearchImagesEditorialTests.cs
+++ b/UnitTests/Search/SearchImagesEditorialTests.cs
@@ -152,7 +152,7 @@ public class SearchImagesEditorialTests
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
-        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("end_date=2015-04-01");
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("date_to=2015-04-01");
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public class SearchImagesEditorialTests
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("search/images/editorial");
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("phrase=cat");
-        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("start_date=2015-04-01");
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("date_from=2015-04-01");
     }
 
     [Fact]


### PR DESCRIPTION
Refactor query parameter constants for Downloads and SearchImagesEditorial
- Replaced `Constants.EndDateKey` with `Constants.DateToKey` in `AddQueryParameter`.
- Replaced `Constants.StartDateKey` with `Constants.DateFromKey` in `AddQueryParameter`.
- Removed obsolete constants (`Constants.EndDateKey` and `Constants.StartDateKey`).
- Updated and adapted tests to reflect the changes in constants.