### PR TITLE
Use long for orders

### DIFF
--- a/GettyImages.Api/Orders/Orders.cs
+++ b/GettyImages.Api/Orders/Orders.cs
@@ -19,7 +19,7 @@ public class Orders : ApiRequest<GetOrderDetailsResponse>
         return new Orders(credentials, baseUrl, customHandler);
     }
 
-    public Orders WithId(int value)
+    public Orders WithId(long value)
     {
         Path = $"/orders/{value}";
         return this;

--- a/UnitTests/Orders/OrdersTests.cs
+++ b/UnitTests/Orders/OrdersTests.cs
@@ -17,4 +17,15 @@ public class OrdersTests
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("orders/1234");
     }
+
+    [Fact]
+    public async Task OrdersBasicWithMaxValue()
+    {
+        var testHandler = TestUtil.CreateTestHandler();
+
+        await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
+            .Orders().WithId(long.MaxValue).ExecuteAsync();
+
+        testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("orders/9223372036854775807");
+    }
 }


### PR DESCRIPTION
Internal issue ref: 86b8bg8p1

The value of order IDs will reach the max of a 32-bit integer.  We'll be implementing these internally soon as 64-bit numbers.