### PR TITLE
Use Trusted Publishing for package push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,8 @@ jobs:
         path: ./GettyImages.Api/bin/Release
 
   publish:
+    permissions:
+      id-token: write # Required for authentication with NuGet.org
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -46,5 +48,11 @@ jobs:
     - name: 'Get Previous tag'
       id: previoustag
       uses: "WyriHaximus/github-action-get-previous-tag@v1"
+    - name: Nuget login (OIDC -> Temp API Key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Publish Package to Nuget
-      run: dotnet nuget push -s https://nuget.org -k "${{secrets.NUGET_PROD_KEY}}" "./artifacts/GettyImages.Api.${{ steps.previoustag.outputs.tag }}.nupkg"
+      run: dotnet nuget push "./artifacts/GettyImages.Api.${{ steps.previoustag.outputs.tag }}.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+      


### PR DESCRIPTION
Uses trusted publishing as documented here:
https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing