### PR TITLE
Use string for order id

### DIFF
--- a/GettyImages.Api/Orders/Orders.cs
+++ b/GettyImages.Api/Orders/Orders.cs
@@ -13,14 +13,14 @@ public class Orders : ApiRequest<GetOrderDetailsResponse>
         Method = "GET";
     }
 
-    protected int id { get; set; }
+    protected string id { get; set; }
 
     internal static Orders GetInstance(Credentials credentials, string baseUrl, DelegatingHandler customHandler)
     {
         return new Orders(credentials, baseUrl, customHandler);
     }
 
-    public Orders WithId(int value)
+    public Orders WithId(string value)
     {
         Path = $"/orders/{value}";
         return this;

--- a/UnitTests/Orders/OrdersTests.cs
+++ b/UnitTests/Orders/OrdersTests.cs
@@ -16,7 +16,7 @@ public class OrdersTests
         var testHandler = TestUtil.CreateTestHandler();
 
         await ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret", testHandler)
-            .Orders().WithId(1234).ExecuteAsync();
+            .Orders().WithId("1234").ExecuteAsync();
 
         testHandler.Request.RequestUri.AbsoluteUri.Should().Contain("orders/1234");
     }


### PR DESCRIPTION
The API is using string for order id everywhere else and this makes it consistent throughout the SDK.

The underlying value of order id will be changing from a 32 bit integer to a 64 bit integer, however, the value should be considered opaque and not treated as anything other than a string.